### PR TITLE
Fix connect timeout and read timeout option

### DIFF
--- a/Tea/core.py
+++ b/Tea/core.py
@@ -101,11 +101,10 @@ class TeaCore:
 
         url = TeaCore.compose_url(request)
         verify = not runtime_option.get('ignoreSSL', False)
-        connect_timeout = runtime_option.get('connectTimeout')
-        connect_timeout = connect_timeout if connect_timeout else DEFAULT_CONNECT_TIMEOUT
 
-        read_timeout = runtime_option.get('readTimeout')
-        read_timeout = read_timeout if read_timeout else DEFAULT_READ_TIMEOUT
+        timeout = runtime_option.get('timeout')
+        connect_timeout = runtime_option.get('connectTimeout', timeout or DEFAULT_CONNECT_TIMEOUT)
+        read_timeout = runtime_option.get('readTimeout',timeout or DEFAULT_READ_TIMEOUT)
 
         connect_timeout, read_timeout = (int(connect_timeout) / 1000, int(read_timeout) / 1000)
 
@@ -170,11 +169,9 @@ class TeaCore:
             verify = runtime_option.get('ca', True) if runtime_option.get('ca', True) is not None else True
         cert = runtime_option.get('cert', None)
 
-        connect_timeout = runtime_option.get('connectTimeout')
-        connect_timeout = connect_timeout if connect_timeout else DEFAULT_CONNECT_TIMEOUT
-
-        read_timeout = runtime_option.get('readTimeout')
-        read_timeout = read_timeout if read_timeout else DEFAULT_READ_TIMEOUT
+        timeout = runtime_option.get('timeout')
+        connect_timeout = runtime_option.get('connectTimeout', timeout or DEFAULT_CONNECT_TIMEOUT)
+        read_timeout = runtime_option.get('readTimeout',timeout or DEFAULT_READ_TIMEOUT)
 
         timeout = (int(connect_timeout) / 1000, int(read_timeout) / 1000)
 


### PR DESCRIPTION

As the [darabonba README](https://github.com/aliyun/darabonba/blob/f0d2d445f94f100bbf25ed265c87d2e050d2f461/doc/demo_sdk.md) describes, the timeout option should be supported.

![image](https://user-images.githubusercontent.com/25344334/169950527-a9464603-543b-49ef-8a0b-d73ad69f27d2.png)
But `tea-python`  doesn't seems not to handle the timeout option.

The logic of requests's `HTTPAdapter` is that for the timeout parameter, you can pass a floating number or an tuple.
https://github.com/psf/requests/blob/79f2ec3acc4e24fef6e6ce31ad7b1d4e2f77be31/requests/adapters.py#L473-L485