### PR TITLE
Fix SSL purpose to SERVER_AUTH

### DIFF
--- a/Tea/core.py
+++ b/Tea/core.py
@@ -121,7 +121,7 @@ class TeaCore:
         connector = None
         ca_cert = certifi.where()
         if ca_cert and request.protocol.upper() == 'HTTPS':
-            ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+            ssl_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
             ssl_context.load_verify_locations(ca_cert)
             connector = aiohttp.TCPConnector(
                 ssl=ssl_context,


### PR DESCRIPTION
This fixes the error on MacOS:

Tea.exceptions.UnretryableException: Cannot connect to host test-bucket12345.oss-cn-hangzhou.aliyuncs.com:443 ssl:default [Cannot create a client socket with a PROTOCOL_TLS_SERVER context (_ssl.c:809)]