### PR TITLE
fix: fix default connect_timeout and read_timeout

### DIFF
--- a/Tea/core.py
+++ b/Tea/core.py
@@ -103,8 +103,8 @@ class TeaCore:
         verify = not runtime_option.get('ignoreSSL', False)
 
         timeout = runtime_option.get('timeout')
-        connect_timeout = runtime_option.get('connectTimeout', timeout or DEFAULT_CONNECT_TIMEOUT)
-        read_timeout = runtime_option.get('readTimeout',timeout or DEFAULT_READ_TIMEOUT)
+        connect_timeout = runtime_option.get('connectTimeout') or timeout or DEFAULT_CONNECT_TIMEOUT
+        read_timeout = runtime_option.get('readTimeout') or timeout or DEFAULT_READ_TIMEOUT
 
         connect_timeout, read_timeout = (int(connect_timeout) / 1000, int(read_timeout) / 1000)
 
@@ -176,8 +176,8 @@ class TeaCore:
         cert = runtime_option.get('cert', None)
 
         timeout = runtime_option.get('timeout')
-        connect_timeout = runtime_option.get('connectTimeout', timeout or DEFAULT_CONNECT_TIMEOUT)
-        read_timeout = runtime_option.get('readTimeout',timeout or DEFAULT_READ_TIMEOUT)
+        connect_timeout = runtime_option.get('connectTimeout') or timeout or DEFAULT_CONNECT_TIMEOUT
+        read_timeout = runtime_option.get('readTimeout') or timeout or DEFAULT_READ_TIMEOUT
 
         timeout = (int(connect_timeout) / 1000, int(read_timeout) / 1000)
 


### PR DESCRIPTION
`runtime_option.get('connectTimeout', timeout or DEFAULT_CONNECT_TIMEOUT)`
`get` 方法携带的默认值只在 `dict` 内没有指定 `key` 时生效，如果 `dict` 内已经有这个 `key` 但是其值为 `None`，那么 `get` 方法会直接返回 `None`，不会使用默认值
此处的期望行为应该是 `connectTimeout` 和 `timeout` 都没有设置时采用 `DEFAULT_CONNECT_TIMEOUT`