### PR TITLE
Add WebSocket client support to darabonba-core (Aone 83973983)

### DIFF
--- a/darabonba/runtime.py
+++ b/darabonba/runtime.py
@@ -1,5 +1,5 @@
 from darabonba.core import DaraModel
-from typing import Dict
+from typing import Dict, Any
 from darabonba.policy.retry import RetryOptions
 
 class ExtendsParameters(DaraModel):
@@ -60,6 +60,15 @@ class RuntimeOptions(DaraModel):
         cert: str = None,
         ca: str = None,
         extends_parameters: ExtendsParameters = None,
+        web_socket_ping_interval: int = None,
+        web_socket_pong_timeout: int = None,
+        web_socket_enable_reconnect: bool = None,
+        web_socket_reconnect_interval: int = None,
+        web_socket_max_reconnect_times: int = None,
+        web_socket_write_timeout: int = None,
+        web_socket_handshake_timeout: int = None,
+        web_socket_handler: Any = None,
+        websocket_sub_protocol: str = None,
     ):
         # retry options
         self.retry_options = retry_options
@@ -101,6 +110,16 @@ class RuntimeOptions(DaraModel):
         self.keep_alive = keep_alive
         # Extends Parameters
         self.extends_parameters = extends_parameters
+        # WebSocket options
+        self.web_socket_ping_interval = web_socket_ping_interval
+        self.web_socket_pong_timeout = web_socket_pong_timeout
+        self.web_socket_enable_reconnect = web_socket_enable_reconnect
+        self.web_socket_reconnect_interval = web_socket_reconnect_interval
+        self.web_socket_max_reconnect_times = web_socket_max_reconnect_times
+        self.web_socket_write_timeout = web_socket_write_timeout
+        self.web_socket_handshake_timeout = web_socket_handshake_timeout
+        self.web_socket_handler = web_socket_handler
+        self.websocket_sub_protocol = websocket_sub_protocol
 
     def validate(self):
         if self.retry_options:
@@ -154,6 +173,22 @@ class RuntimeOptions(DaraModel):
             result['keepAlive'] = self.keep_alive
         if self.extends_parameters is not None:
             result['extendsParameters'] = self.extends_parameters.to_map()
+        if self.web_socket_ping_interval is not None:
+            result['webSocketPingInterval'] = self.web_socket_ping_interval
+        if self.web_socket_pong_timeout is not None:
+            result['webSocketPongTimeout'] = self.web_socket_pong_timeout
+        if self.web_socket_enable_reconnect is not None:
+            result['webSocketEnableReconnect'] = self.web_socket_enable_reconnect
+        if self.web_socket_reconnect_interval is not None:
+            result['webSocketReconnectInterval'] = self.web_socket_reconnect_interval
+        if self.web_socket_max_reconnect_times is not None:
+            result['webSocketMaxReconnectTimes'] = self.web_socket_max_reconnect_times
+        if self.web_socket_write_timeout is not None:
+            result['webSocketWriteTimeout'] = self.web_socket_write_timeout
+        if self.web_socket_handshake_timeout is not None:
+            result['webSocketHandshakeTimeout'] = self.web_socket_handshake_timeout
+        if self.websocket_sub_protocol is not None:
+            result['websocketSubProtocol'] = self.websocket_sub_protocol
         return result
 
     def from_map(self, m: dict = None):
@@ -199,4 +234,20 @@ class RuntimeOptions(DaraModel):
         if m.get('extendsParameters') is not None:
             temp_model = ExtendsParameters()
             self.extends_parameters = temp_model.from_map(m['extendsParameters'])
+        if m.get('webSocketPingInterval') is not None:
+            self.web_socket_ping_interval = m.get('webSocketPingInterval')
+        if m.get('webSocketPongTimeout') is not None:
+            self.web_socket_pong_timeout = m.get('webSocketPongTimeout')
+        if m.get('webSocketEnableReconnect') is not None:
+            self.web_socket_enable_reconnect = m.get('webSocketEnableReconnect')
+        if m.get('webSocketReconnectInterval') is not None:
+            self.web_socket_reconnect_interval = m.get('webSocketReconnectInterval')
+        if m.get('webSocketMaxReconnectTimes') is not None:
+            self.web_socket_max_reconnect_times = m.get('webSocketMaxReconnectTimes')
+        if m.get('webSocketWriteTimeout') is not None:
+            self.web_socket_write_timeout = m.get('webSocketWriteTimeout')
+        if m.get('webSocketHandshakeTimeout') is not None:
+            self.web_socket_handshake_timeout = m.get('webSocketHandshakeTimeout')
+        if m.get('websocketSubProtocol') is not None:
+            self.websocket_sub_protocol = m.get('websocketSubProtocol')
         return self

--- a/darabonba/runtime.py
+++ b/darabonba/runtime.py
@@ -68,7 +68,6 @@ class RuntimeOptions(DaraModel):
         web_socket_write_timeout: int = None,
         web_socket_handshake_timeout: int = None,
         web_socket_handler: Any = None,
-        websocket_sub_protocol: str = None,
     ):
         # retry options
         self.retry_options = retry_options
@@ -119,7 +118,6 @@ class RuntimeOptions(DaraModel):
         self.web_socket_write_timeout = web_socket_write_timeout
         self.web_socket_handshake_timeout = web_socket_handshake_timeout
         self.web_socket_handler = web_socket_handler
-        self.websocket_sub_protocol = websocket_sub_protocol
 
     def validate(self):
         if self.retry_options:
@@ -187,8 +185,6 @@ class RuntimeOptions(DaraModel):
             result['webSocketWriteTimeout'] = self.web_socket_write_timeout
         if self.web_socket_handshake_timeout is not None:
             result['webSocketHandshakeTimeout'] = self.web_socket_handshake_timeout
-        if self.websocket_sub_protocol is not None:
-            result['websocketSubProtocol'] = self.websocket_sub_protocol
         return result
 
     def from_map(self, m: dict = None):
@@ -248,6 +244,4 @@ class RuntimeOptions(DaraModel):
             self.web_socket_write_timeout = m.get('webSocketWriteTimeout')
         if m.get('webSocketHandshakeTimeout') is not None:
             self.web_socket_handshake_timeout = m.get('webSocketHandshakeTimeout')
-        if m.get('websocketSubProtocol') is not None:
-            self.websocket_sub_protocol = m.get('websocketSubProtocol')
         return self

--- a/darabonba/websocket.py
+++ b/darabonba/websocket.py
@@ -104,10 +104,6 @@ def get_web_socket_handler(runtime: Any):
     return _get_runtime_value(runtime, 'webSocketHandler', 'web_socket_handler')
 
 
-def get_websocket_sub_protocol(runtime: Any) -> Optional[str]:
-    return _get_runtime_value(runtime, 'websocketSubProtocol', 'websocket_sub_protocol')
-
-
 def new_websocket_response(
     status_code: int,
     status_message: str,

--- a/darabonba/websocket.py
+++ b/darabonba/websocket.py
@@ -166,7 +166,6 @@ class DefaultWebSocketClient:
         self.pong_timeout = 5000
         self.max_reconnect_times = 5
         self._reconnect_lock = threading.Lock()
-        self.websocket_sub_protocol: Optional[str] = None
         self._abort_event = threading.Event()
         self._ws_thread: Optional[threading.Thread] = None
         self._message_handlers_started = False
@@ -182,7 +181,6 @@ class DefaultWebSocketClient:
         self.request = request
         self.runtime_object = runtime_object
         self._update_timeout_config(runtime_object)
-        self.websocket_sub_protocol = get_websocket_sub_protocol(runtime_object)
         self.state = STATE_CONNECTING
         self.stopped = False
         self.pong_received = False
@@ -284,7 +282,6 @@ class DefaultWebSocketClient:
         self.ws_app = websocket.WebSocketApp(
             request_url,
             header=headers,
-            subprotocols=None,
             on_open=on_open,
             on_message=self._on_message,
             on_error=on_error,

--- a/darabonba/websocket.py
+++ b/darabonba/websocket.py
@@ -208,10 +208,6 @@ class DefaultWebSocketClient:
                 if value and key.lower() not in ('host', 'content-length'):
                     headers[key] = value
 
-        if self.websocket_sub_protocol:
-            headers['Sec-WebSocket-Protocol'] = self.websocket_sub_protocol
-
-        subprotocols = [self.websocket_sub_protocol] if self.websocket_sub_protocol else None
         sslopt = self._configure_tls(runtime_object, parsed.scheme)
         proxy_kwargs = self._configure_proxy(parsed, runtime_object, request)
 
@@ -288,7 +284,7 @@ class DefaultWebSocketClient:
         self.ws_app = websocket.WebSocketApp(
             request_url,
             header=headers,
-            subprotocols=subprotocols,
+            subprotocols=None,
             on_open=on_open,
             on_message=self._on_message,
             on_error=on_error,

--- a/darabonba/websocket.py
+++ b/darabonba/websocket.py
@@ -1,0 +1,820 @@
+import base64
+import hashlib
+import os
+import ssl
+import threading
+import time
+from datetime import datetime
+from enum import IntEnum
+from typing import Any, Callable, Dict, List, Optional, Union
+from urllib.parse import parse_qs, urlencode, urlparse
+
+import websocket
+from websocket._abnf import ABNF
+
+from darabonba.request import DaraRequest
+from darabonba.response import DaraResponse
+from darabonba.runtime import RuntimeOptions
+
+
+class WebSocketMessageType(IntEnum):
+    Text = 0
+    Binary = 1
+    Ping = 2
+    Pong = 3
+    Close = 4
+
+
+class WebSocketMessage:
+    def __init__(
+        self,
+        type: WebSocketMessageType,
+        payload: bytes,
+        headers: Optional[Dict[str, str]] = None,
+        timestamp: Optional[datetime] = None,
+    ):
+        self.type = type
+        self.payload = payload
+        self.headers = headers or {}
+        self.timestamp = timestamp or datetime.now()
+
+
+class WebSocketSessionInfo:
+    def __init__(
+        self,
+        session_id: str,
+        request_id: str = '',
+        connected_at: Optional[datetime] = None,
+        remote_addr: str = '',
+        local_addr: str = '',
+        attributes: Optional[Dict[str, Any]] = None,
+    ):
+        self.session_id = session_id
+        self.request_id = request_id
+        self.connected_at = connected_at or datetime.now()
+        self.remote_addr = remote_addr
+        self.local_addr = local_addr
+        self.attributes = attributes or {}
+
+
+STATE_DISCONNECTED = 0
+STATE_CONNECTING = 1
+STATE_CONNECTED = 2
+STATE_DISCONNECTING = 3
+
+
+def _get_runtime_value(runtime: Any, camel_key: str, snake_key: str = None):
+    if runtime is None:
+        return None
+    if isinstance(runtime, dict):
+        return runtime.get(camel_key)
+    key = snake_key or camel_key
+    return getattr(runtime, key, None)
+
+
+def get_web_socket_ping_interval(runtime: Any) -> Optional[int]:
+    return _get_runtime_value(runtime, 'webSocketPingInterval', 'web_socket_ping_interval')
+
+
+def get_web_socket_pong_timeout(runtime: Any) -> Optional[int]:
+    return _get_runtime_value(runtime, 'webSocketPongTimeout', 'web_socket_pong_timeout')
+
+
+def get_web_socket_enable_reconnect(runtime: Any) -> Optional[bool]:
+    return _get_runtime_value(runtime, 'webSocketEnableReconnect', 'web_socket_enable_reconnect')
+
+
+def get_web_socket_reconnect_interval(runtime: Any) -> Optional[int]:
+    return _get_runtime_value(runtime, 'webSocketReconnectInterval', 'web_socket_reconnect_interval')
+
+
+def get_web_socket_max_reconnect_times(runtime: Any) -> Optional[int]:
+    return _get_runtime_value(runtime, 'webSocketMaxReconnectTimes', 'web_socket_max_reconnect_times')
+
+
+def get_web_socket_write_timeout(runtime: Any) -> Optional[int]:
+    return _get_runtime_value(runtime, 'webSocketWriteTimeout', 'web_socket_write_timeout')
+
+
+def get_web_socket_handshake_timeout(runtime: Any) -> Optional[int]:
+    return _get_runtime_value(runtime, 'webSocketHandshakeTimeout', 'web_socket_handshake_timeout')
+
+
+def get_web_socket_handler(runtime: Any):
+    return _get_runtime_value(runtime, 'webSocketHandler', 'web_socket_handler')
+
+
+def get_websocket_sub_protocol(runtime: Any) -> Optional[str]:
+    return _get_runtime_value(runtime, 'websocketSubProtocol', 'websocket_sub_protocol')
+
+
+def new_websocket_response(
+    status_code: int,
+    status_message: str,
+    headers: Optional[Dict[str, Any]] = None,
+) -> DaraResponse:
+    res = DaraResponse()
+    res.status_code = status_code
+    res.status_message = status_message
+    normalized_headers: Dict[str, str] = {}
+    for key, val in (headers or {}).items():
+        if val is not None:
+            if isinstance(val, list):
+                normalized_headers[key.lower()] = str(val[0])
+            else:
+                normalized_headers[key.lower()] = str(val)
+    res.headers = normalized_headers
+    return res
+
+
+class WebSocketHandler:
+    def after_connection_established(self, session: WebSocketSessionInfo) -> None:
+        return None
+
+    def handle_raw_message(self, session: WebSocketSessionInfo, message: WebSocketMessage) -> None:
+        return None
+
+    def handle_error(self, session: WebSocketSessionInfo, err: Exception) -> None:
+        return None
+
+    def after_connection_closed(self, session: WebSocketSessionInfo, code: int, reason: str) -> None:
+        return None
+
+
+class AbstractWebSocketHandler(WebSocketHandler):
+    pass
+
+
+class DefaultWebSocketClient:
+    def __init__(self, handler: WebSocketHandler):
+        if handler is None:
+            raise ValueError('handler cannot be nil')
+        self.handler = handler
+        self.stopped = False
+        self.pong_received = False
+        self.state = STATE_DISCONNECTED
+        self.ws_app: Optional[websocket.WebSocketApp] = None
+        self.session: Optional[WebSocketSessionInfo] = None
+        self.request: Optional[DaraRequest] = None
+        self.runtime_object: Any = None
+        self.reconnect_count = 0
+        self._ping_timer: Optional[threading.Timer] = None
+        self.ping_interval = 30000
+        self.reconnect_interval = 5000
+        self.write_timeout = 30000
+        self.read_timeout = 0
+        self.pong_timeout = 5000
+        self.max_reconnect_times = 5
+        self._reconnect_lock = threading.Lock()
+        self.websocket_sub_protocol: Optional[str] = None
+        self._abort_event = threading.Event()
+        self._ws_thread: Optional[threading.Thread] = None
+        self._message_handlers_started = False
+        self._connect_error: Optional[Exception] = None
+        self._handshake_response: Dict[str, Any] = {}
+
+    def connect(self, request: DaraRequest, runtime_object: Any) -> DaraResponse:
+        if request is None:
+            raise ValueError('request cannot be nil')
+        if runtime_object is None:
+            raise ValueError('runtimeObject cannot be nil')
+
+        self.request = request
+        self.runtime_object = runtime_object
+        self._update_timeout_config(runtime_object)
+        self.websocket_sub_protocol = get_websocket_sub_protocol(runtime_object)
+        self.state = STATE_CONNECTING
+        self.stopped = False
+        self.pong_received = False
+        self._connect_error = None
+        self._handshake_response = {}
+        self._abort_event.clear()
+
+        request_url = build_websocket_url(request)
+        parsed = urlparse(request_url)
+        if not parsed.scheme or not parsed.netloc:
+            self.state = STATE_DISCONNECTED
+            raise ValueError(f'invalid websocket url: {request_url}')
+
+        handshake_timeout = get_web_socket_handshake_timeout(runtime_object)
+        if not handshake_timeout or handshake_timeout <= 0:
+            handshake_timeout = 30000
+
+        connect_timeout = _get_connect_timeout(runtime_object)
+
+        headers: Dict[str, str] = {}
+        if request.headers:
+            for key, value in request.headers.items():
+                if value and key.lower() not in ('host', 'content-length'):
+                    headers[key] = value
+
+        if self.websocket_sub_protocol:
+            headers['Sec-WebSocket-Protocol'] = self.websocket_sub_protocol
+
+        subprotocols = [self.websocket_sub_protocol] if self.websocket_sub_protocol else None
+        sslopt = self._configure_tls(runtime_object, parsed.scheme)
+        proxy_kwargs = self._configure_proxy(parsed, runtime_object, request)
+
+        connected_event = threading.Event()
+
+        def on_open(ws_app):
+            self.ws_app = ws_app
+            self.state = STATE_CONNECTED
+            self._setup_pong_handler()
+            self._start_message_handlers(ws_app)
+            if self.ping_interval > 0:
+                self._start_ping_pong()
+
+            resp_headers: Dict[str, Any] = {}
+            status_code = 101
+            status_message = 'Switching Protocols'
+            if ws_app.sock is not None:
+                if hasattr(ws_app.sock, 'headers') and ws_app.sock.headers:
+                    resp_headers = dict(ws_app.sock.headers)
+                if hasattr(ws_app.sock, 'status') and ws_app.sock.status:
+                    status_code = ws_app.sock.status
+                if hasattr(ws_app.sock, 'status_message') and ws_app.sock.status_message:
+                    status_message = ws_app.sock.status_message
+
+            session_id = (
+                resp_headers.get('x-acs-ws-session-id')
+                or resp_headers.get('X-Acs-Ws-Session-Id')
+                or _generate_session_id()
+            )
+            request_id = (
+                resp_headers.get('x-acs-request-id')
+                or resp_headers.get('X-Acs-Request-Id')
+                or ''
+            )
+            if isinstance(session_id, list):
+                session_id = session_id[0]
+            if isinstance(request_id, list):
+                request_id = request_id[0]
+
+            self.session = WebSocketSessionInfo(
+                session_id=str(session_id),
+                request_id=str(request_id),
+                connected_at=datetime.now(),
+                remote_addr=request_url,
+                local_addr='',
+                attributes={},
+            )
+
+            try:
+                self.handler.after_connection_established(self.session)
+            except Exception as err:
+                self._connect_error = err
+                self.state = STATE_DISCONNECTED
+                self.stopped = True
+                try:
+                    ws_app.close()
+                except Exception:
+                    pass
+                connected_event.set()
+                return
+
+            self._handshake_response = {
+                'status_code': status_code,
+                'status_message': status_message,
+                'headers': resp_headers,
+            }
+            connected_event.set()
+
+        def on_error(ws_app, error):
+            if self.state == STATE_CONNECTING:
+                self._connect_error = error if isinstance(error, Exception) else Exception(str(error))
+                connected_event.set()
+
+        self.ws_app = websocket.WebSocketApp(
+            request_url,
+            header=headers,
+            subprotocols=subprotocols,
+            on_open=on_open,
+            on_message=self._on_message,
+            on_error=on_error,
+            on_close=self._on_close,
+            on_pong=self._on_pong,
+        )
+
+        run_kwargs = {
+            'sslopt': sslopt,
+            'ping_interval': 0,
+            'ping_timeout': None,
+        }
+        run_kwargs.update(proxy_kwargs)
+
+        self._ws_thread = threading.Thread(
+            target=self.ws_app.run_forever,
+            kwargs=run_kwargs,
+            daemon=True,
+        )
+        self._ws_thread.start()
+
+        timeout_seconds = max(connect_timeout, handshake_timeout) / 1000
+        if not connected_event.wait(timeout=timeout_seconds):
+            self.state = STATE_DISCONNECTED
+            self._cleanup_connection()
+            raise TimeoutError('WebSocket connection timeout')
+
+        if self._connect_error is not None:
+            self._cleanup_connection()
+            raise self._connect_error
+
+        return new_websocket_response(
+            self._handshake_response.get('status_code', 101),
+            self._handshake_response.get('status_message', 'Switching Protocols'),
+            self._handshake_response.get('headers', {}),
+        )
+
+    def disconnect(self) -> None:
+        self._disconnect_internal(1000, 'Normal closure')
+
+    def _disconnect_internal(self, code: int, reason: str) -> None:
+        if self.state == STATE_DISCONNECTED and not self._ws_thread:
+            return
+
+        self.state = STATE_DISCONNECTING
+        self._stop_ping_pong()
+        self.stopped = True
+
+        ws_app = self.ws_app
+        self.ws_app = None
+        if ws_app is not None:
+            try:
+                ws_app.close(status=code, reason=reason)
+            except Exception:
+                pass
+
+        self._wait_for_close()
+
+        if self.session:
+            try:
+                self.handler.after_connection_closed(self.session, code, reason)
+            except Exception:
+                pass
+
+        self.state = STATE_DISCONNECTED
+        self._abort_event.set()
+
+    def reconnect(self) -> DaraResponse:
+        return self._reconnect_internal(False)
+
+    def reconnect_gracefully(self) -> DaraResponse:
+        return self._reconnect_internal(True)
+
+    def _reconnect_internal(self, graceful: bool) -> DaraResponse:
+        if not graceful and self.is_connected():
+            raise Exception('already connected')
+
+        if self._abort_event.is_set():
+            raise Exception('connection aborted')
+
+        if not self._reconnect_lock.acquire(blocking=False):
+            raise Exception('reconnect already in progress')
+
+        try:
+            if not get_web_socket_enable_reconnect(self.runtime_object):
+                raise Exception('reconnect is disabled')
+
+            if self.reconnect_count >= self.max_reconnect_times:
+                raise Exception(f'max reconnect times reached: {self.max_reconnect_times}')
+
+            previous_session_id = ''
+            if graceful:
+                if self.session and self.session.session_id:
+                    previous_session_id = self.session.session_id
+                else:
+                    raise Exception('graceful reconnection requires existing session ID')
+
+            self._cleanup_resources()
+
+            self.stopped = False
+            self.reconnect_count += 1
+
+            if self.request is None:
+                raise Exception('request is nil, cannot reconnect')
+
+            if graceful and previous_session_id:
+                if self.request.headers is None:
+                    self.request.headers = {}
+                self.request.headers['X-Acs-Ws-Session-Id'] = previous_session_id
+            elif self.request.headers:
+                self.request.headers.pop('X-Acs-Ws-Session-Id', None)
+
+            self._sleep_interruptible(self.reconnect_interval)
+
+            if self._abort_event.is_set():
+                raise Exception('connection aborted')
+
+            result = self.connect(self.request, self.runtime_object)
+            self.reconnect_count = 0
+            return result
+        finally:
+            self._reconnect_lock.release()
+
+    def _cleanup_resources(self) -> None:
+        self.state = STATE_DISCONNECTING
+        self._stop_ping_pong()
+        self.stopped = True
+
+        ws_app = self.ws_app
+        self.ws_app = None
+        if ws_app is not None:
+            try:
+                ws_app.close(status=1001, reason='Reconnecting')
+            except Exception:
+                pass
+            self._wait_for_close()
+
+        self.session = None
+        self._message_handlers_started = False
+        self.state = STATE_DISCONNECTED
+
+    def is_connected(self) -> bool:
+        return self.state == STATE_CONNECTED
+
+    def send_text(self, text: str) -> None:
+        if not self.is_connected():
+            raise Exception('not connected')
+        ws_app = self.ws_app
+        if ws_app is None:
+            raise Exception('connection is nil')
+        self._send_with_timeout(lambda: ws_app.send(text))
+
+    def send_binary(self, data: bytes) -> None:
+        if not self.is_connected():
+            raise Exception('not connected')
+        ws_app = self.ws_app
+        if ws_app is None:
+            raise Exception('connection is nil')
+        self._send_with_timeout(lambda: ws_app.send(data, opcode=ABNF.OPCODE_BINARY))
+
+    def get_session_info(self) -> Optional[WebSocketSessionInfo]:
+        return self.session
+
+    def close(self) -> None:
+        self._disconnect_internal(1000, 'Client closed')
+
+    def configure_tls(self, runtime_object: Any, scheme: str = 'wss') -> Dict[str, Any]:
+        return self._configure_tls(runtime_object, scheme)
+
+    def configure_proxy(
+        self,
+        parsed: Any,
+        runtime_object: Any,
+        request: DaraRequest,
+    ) -> Dict[str, Any]:
+        return self._configure_proxy(parsed, runtime_object, request)
+
+    def configure_socks5_proxy(self, runtime_object: Any) -> Dict[str, Any]:
+        proxy_kwargs: Dict[str, Any] = {}
+        socks5_proxy = _get_runtime_value(runtime_object, 'socks5Proxy', 'socks_5proxy')
+        if socks5_proxy:
+            proxy_kwargs['proxy_type'] = 'socks5'
+            proxy_kwargs['http_proxy_host'] = socks5_proxy
+        return proxy_kwargs
+
+    def configure_http_proxy(
+        self,
+        parsed: Any,
+        runtime_object: Any,
+        request: DaraRequest,
+    ) -> Dict[str, Any]:
+        return self._configure_proxy(parsed, runtime_object, request)
+
+    def _configure_tls(self, runtime_object: Any, scheme: str) -> Dict[str, Any]:
+        if scheme not in ('wss', 'https'):
+            return {}
+
+        ignore_ssl = _get_runtime_value(runtime_object, 'ignoreSSL', 'ignore_ssl')
+        sslopt: Dict[str, Any] = {}
+        if ignore_ssl:
+            sslopt['cert_reqs'] = ssl.CERT_NONE
+            sslopt['check_hostname'] = False
+        else:
+            sslopt['cert_reqs'] = ssl.CERT_REQUIRED
+
+        cert = _get_runtime_value(runtime_object, 'cert', 'cert')
+        key = _get_runtime_value(runtime_object, 'key', 'key')
+        ca = _get_runtime_value(runtime_object, 'ca', 'ca')
+        if cert and key:
+            sslopt['certfile'] = cert
+            sslopt['keyfile'] = key
+        if ca:
+            sslopt['ca_certs'] = ca
+        return sslopt
+
+    def _configure_proxy(
+        self,
+        parsed: Any,
+        runtime_object: Any,
+        request: DaraRequest,
+    ) -> Dict[str, Any]:
+        proxy_kwargs: Dict[str, Any] = {}
+        socks5_proxy = _get_runtime_value(runtime_object, 'socks5Proxy', 'socks_5proxy')
+        if socks5_proxy:
+            proxy_kwargs['proxy_type'] = 'socks5'
+            proxy_kwargs['http_proxy_host'] = socks5_proxy
+            return proxy_kwargs
+
+        if parsed is None:
+            return proxy_kwargs
+
+        protocol = parsed.scheme.replace(':', '')
+        host = parsed.hostname
+        no_proxy_list = _get_no_proxy(protocol, runtime_object)
+        for no_proxy_host in no_proxy_list:
+            if no_proxy_host.strip() == host:
+                return proxy_kwargs
+
+        proxy_url = _get_http_proxy_url(protocol, host, runtime_object)
+        if not proxy_url:
+            return proxy_kwargs
+
+        proxy_parsed = urlparse(proxy_url)
+        proxy_kwargs['http_proxy_host'] = proxy_parsed.hostname
+        proxy_kwargs['http_proxy_port'] = proxy_parsed.port or (
+            443 if protocol in ('wss', 'https') else 80
+        )
+        if proxy_parsed.username and proxy_parsed.password:
+            if request.headers is None:
+                request.headers = {}
+            auth = f'{proxy_parsed.username}:{proxy_parsed.password}'
+            request.headers['Proxy-Authorization'] = (
+                'Basic ' + base64.b64encode(auth.encode()).decode()
+            )
+        return proxy_kwargs
+
+    def _update_timeout_config(self, runtime_object: Any) -> None:
+        ping_interval = get_web_socket_ping_interval(runtime_object)
+        self.ping_interval = ping_interval if ping_interval and ping_interval > 0 else 30000
+
+        reconnect_interval = get_web_socket_reconnect_interval(runtime_object)
+        self.reconnect_interval = reconnect_interval if reconnect_interval and reconnect_interval > 0 else 5000
+
+        write_timeout = get_web_socket_write_timeout(runtime_object)
+        self.write_timeout = write_timeout if write_timeout and write_timeout > 0 else 30000
+
+        read_timeout = _get_runtime_value(runtime_object, 'readTimeout', 'read_timeout')
+        self.read_timeout = read_timeout if read_timeout and read_timeout > 0 else 0
+
+        pong_timeout = get_web_socket_pong_timeout(runtime_object)
+        self.pong_timeout = pong_timeout if pong_timeout and pong_timeout > 0 else 5000
+
+        max_reconnect_times = get_web_socket_max_reconnect_times(runtime_object)
+        self.max_reconnect_times = max_reconnect_times if max_reconnect_times and max_reconnect_times > 0 else 5
+
+    def _setup_pong_handler(self) -> None:
+        self.pong_received = False
+
+    def _on_pong(self, ws_app, _data) -> None:
+        self.pong_received = True
+
+    def _start_message_handlers(self, ws_app) -> None:
+        if self._message_handlers_started:
+            return
+        self._message_handlers_started = True
+        self.ws_app = ws_app
+
+    def _on_message(self, ws_app, message) -> None:
+        if self.stopped:
+            return
+
+        if isinstance(message, bytes):
+            msg_type = WebSocketMessageType.Binary
+            payload = message
+        else:
+            msg_type = WebSocketMessageType.Text
+            payload = message.encode('utf-8') if isinstance(message, str) else bytes(message)
+
+        msg = WebSocketMessage(type=msg_type, payload=payload, headers={}, timestamp=datetime.now())
+        if not self.session:
+            return
+
+        try:
+            self.handler.handle_raw_message(self.session, msg)
+        except Exception as err:
+            try:
+                self.handler.handle_error(self.session, err)
+            except Exception:
+                pass
+
+    def _on_error(self, ws_app, error) -> None:
+        if self.stopped or not self.session:
+            return
+        err = error if isinstance(error, Exception) else Exception(str(error))
+        try:
+            self.handler.handle_error(self.session, err)
+        except Exception:
+            pass
+
+    def _on_close(self, ws_app, close_status_code, close_msg) -> None:
+        if self.stopped:
+            return
+
+        reason = close_msg or ''
+        if self.session and close_status_code not in (1000, 1001):
+            try:
+                self.handler.handle_error(
+                    self.session,
+                    Exception(f'WebSocket closed: {close_status_code} {reason}'),
+                )
+            except Exception:
+                pass
+
+        if get_web_socket_enable_reconnect(self.runtime_object) and self.request and not self.stopped:
+            try:
+                self.reconnect()
+            except Exception:
+                pass
+
+    def _start_ping_pong(self) -> None:
+        if self.ping_interval <= 0:
+            return
+        self._stop_ping_pong()
+        self._schedule_ping()
+
+    def _schedule_ping(self) -> None:
+        if self.stopped or not self.is_connected():
+            return
+
+        self.pong_received = False
+        try:
+            if self.ws_app and self.ws_app.sock:
+                self.ws_app.sock.ping()
+        except Exception as err:
+            if self.session:
+                try:
+                    self.handler.handle_error(self.session, err)
+                except Exception:
+                    pass
+            return
+
+        def check_pong():
+            if self.stopped:
+                return
+            if not self.pong_received and get_web_socket_enable_reconnect(self.runtime_object):
+                try:
+                    self.reconnect()
+                except Exception:
+                    pass
+            if not self.stopped and self.is_connected():
+                self._schedule_ping()
+
+        self._ping_timer = threading.Timer(self.pong_timeout / 1000, check_pong)
+        self._ping_timer.daemon = True
+        self._ping_timer.start()
+
+    def _stop_ping_pong(self) -> None:
+        if self._ping_timer is not None:
+            self._ping_timer.cancel()
+            self._ping_timer = None
+
+    def _cleanup_connection(self) -> None:
+        self._stop_ping_pong()
+        self.stopped = True
+        ws_app = self.ws_app
+        self.ws_app = None
+        if ws_app is not None:
+            try:
+                ws_app.close()
+            except Exception:
+                pass
+            self._wait_for_close()
+
+    def _send_with_timeout(self, send_fn: Callable[[], None]) -> None:
+        if self.write_timeout <= 0:
+            send_fn()
+            return
+
+        error: List[Optional[Exception]] = [None]
+
+        def do_send():
+            try:
+                send_fn()
+            except Exception as err:
+                error[0] = err
+
+        thread = threading.Thread(target=do_send, daemon=True)
+        thread.start()
+        thread.join(timeout=self.write_timeout / 1000)
+        if thread.is_alive():
+            raise TimeoutError('write timeout')
+        if error[0] is not None:
+            raise error[0]
+
+    def _wait_for_close(self, timeout: float = 5.0) -> None:
+        thread = self._ws_thread
+        if thread is None:
+            return
+        if thread is threading.current_thread():
+            return
+        thread.join(timeout=timeout)
+
+    def _sleep_interruptible(self, ms: int) -> bool:
+        return self._abort_event.wait(timeout=ms / 1000)
+
+
+def new_default_websocket_client(handler: WebSocketHandler) -> DefaultWebSocketClient:
+    return DefaultWebSocketClient(handler)
+
+
+def new_websocket_client_and_connect(
+    request: DaraRequest,
+    runtime_object: Any,
+):
+    if runtime_object is None:
+        raise ValueError('runtimeObject cannot be nil')
+
+    handler = get_web_socket_handler(runtime_object)
+    if handler is None:
+        raise ValueError(
+            'WebSocketHandler is required: please set it in runtimeObject.webSocketHandler'
+        )
+
+    client = DefaultWebSocketClient(handler)
+    response = client.connect(request, runtime_object)
+    return client, response
+
+
+def build_websocket_url(request: DaraRequest) -> str:
+    if request is None:
+        raise ValueError('request cannot be nil')
+
+    protocol = request.protocol or 'ws'
+    protocol = protocol.lower()
+    if protocol == 'http':
+        protocol = 'ws'
+    elif protocol == 'https':
+        protocol = 'wss'
+
+    domain = getattr(request, 'domain', None)
+    if not domain and request.headers:
+        domain = request.headers.get('host')
+    if not domain:
+        raise ValueError('domain is required (set in request.headers["host"] or request.domain)')
+
+    request_url = f'{protocol}://{domain}'
+    request_url += request.pathname or '/'
+
+    if request.query:
+        qs = urlencode(request.query, doseq=True)
+        if qs:
+            request_url += '&' + qs if '?' in request_url else '?' + qs
+
+    return request_url
+
+
+def convert_to_websocket_message_type(message_type: int) -> WebSocketMessageType:
+    mapping = {
+        1: WebSocketMessageType.Text,
+        2: WebSocketMessageType.Binary,
+        9: WebSocketMessageType.Ping,
+        10: WebSocketMessageType.Pong,
+        8: WebSocketMessageType.Close,
+    }
+    return mapping.get(message_type, WebSocketMessageType.Binary)
+
+
+def _generate_session_id() -> str:
+    return f'ws-session-{int(time.time() * 1000)}{os.urandom(4).hex()}'
+
+
+def _get_connect_timeout(runtime_object: Any) -> int:
+    connect_timeout = _get_runtime_value(runtime_object, 'connectTimeout', 'connect_timeout')
+    if connect_timeout and connect_timeout > 0:
+        return connect_timeout
+    return 10000
+
+
+def _get_no_proxy(protocol: str, runtime: Any) -> List[str]:
+    no_proxy = _get_runtime_value(runtime, 'noProxy', 'no_proxy')
+    if no_proxy:
+        return no_proxy.split(',')
+    env_no_proxy = os.environ.get('NO_PROXY') or os.environ.get('no_proxy')
+    if env_no_proxy:
+        return env_no_proxy.split(',')
+    return []
+
+
+def _get_http_proxy_url(protocol: str, host: str, runtime: Any) -> Optional[str]:
+    no_proxy_list = _get_no_proxy(protocol, runtime)
+    for no_proxy_host in no_proxy_list:
+        if no_proxy_host.strip() == host:
+            return None
+
+    proxy_protocol = protocol
+    if protocol == 'wss':
+        proxy_protocol = 'https'
+    elif protocol == 'ws':
+        proxy_protocol = 'http'
+
+    if proxy_protocol == 'https':
+        proxy_url = _get_runtime_value(runtime, 'httpsProxy', 'https_proxy')
+        if proxy_url:
+            return proxy_url
+        return os.environ.get('HTTPS_PROXY') or os.environ.get('https_proxy')
+    proxy_url = _get_runtime_value(runtime, 'httpProxy', 'http_proxy')
+    if proxy_url:
+        return proxy_url
+    return os.environ.get('HTTP_PROXY') or os.environ.get('http_proxy')

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,8 @@ else:
     install_requires.append('requests>=2.21.0, <3.0.0')
     install_requires.append('aiohttp>=3.7.0, <4.0.0')
 
+install_requires.append('websocket-client>=1.6.0, <2.0.0')
+
 if ssl.OPENSSL_VERSION_INFO is not None and len(ssl.OPENSSL_VERSION_INFO) >= 3 and ssl.OPENSSL_VERSION_INFO[:3] >= (
         1, 1, 1):
     pass

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -8,6 +8,8 @@ from base64 import b64encode
 from datetime import datetime
 from urllib.parse import urlparse
 
+import websocket as ws_client
+
 from darabonba.request import DaraRequest
 from darabonba.runtime import RuntimeOptions
 from darabonba.websocket import (
@@ -311,6 +313,44 @@ class TestWebSocket(unittest.TestCase):
             client.close()
         finally:
             server.close()
+
+    def test_connect_passes_through_websocket_protocol_header(self):
+        captured = {}
+
+        class CapturingWebSocketApp:
+            def __init__(self, url, header=None, **kwargs):
+                captured['header'] = header or {}
+                self.sock = None
+
+            def run_forever(self, **kwargs):
+                return True
+
+            def close(self, **kwargs):
+                return None
+
+        original = ws_client.WebSocketApp
+        ws_client.WebSocketApp = CapturingWebSocketApp
+        try:
+            request = DaraRequest()
+            request.protocol = 'ws'
+            request.domain = '127.0.0.1:59999'
+            request.pathname = '/'
+            request.headers = {
+                'host': '127.0.0.1:59999',
+                'sec-websocket-protocol': 'awap',
+            }
+            runtime = RuntimeOptions(
+                connect_timeout=50,
+                web_socket_handshake_timeout=50,
+                web_socket_ping_interval=0,
+            )
+            client = new_default_websocket_client(MockWebSocketHandler())
+            with self.assertRaises(Exception):
+                client.connect(request, runtime)
+            self.assertEqual('awap', captured['header'].get('sec-websocket-protocol'))
+            self.assertNotIn('Sec-WebSocket-Protocol', captured['header'])
+        finally:
+            ws_client.WebSocketApp = original
 
     def test_configure_tls(self):
         client = DefaultWebSocketClient(MockWebSocketHandler())

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -418,7 +418,6 @@ class TestWebSocket(unittest.TestCase):
                 read_timeout=5000,
                 web_socket_ping_interval=0,
                 web_socket_enable_reconnect=False,
-                websocket_sub_protocol='awap',
             )
             handler = MockWebSocketHandler()
             client = new_default_websocket_client(handler)
@@ -469,7 +468,6 @@ class TestWebSocket(unittest.TestCase):
                 read_timeout=5000,
                 web_socket_ping_interval=0,
                 web_socket_enable_reconnect=False,
-                websocket_sub_protocol='general',
             )
             handler = MockWebSocketHandler()
             client = new_default_websocket_client(handler)
@@ -511,7 +509,6 @@ class TestWebSocket(unittest.TestCase):
                 read_timeout=5000,
                 web_socket_ping_interval=0,
                 web_socket_enable_reconnect=False,
-                websocket_sub_protocol='general',
             )
             handler = MockWebSocketHandler()
             client = new_default_websocket_client(handler)

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,0 +1,352 @@
+import hashlib
+import socket
+import ssl
+import struct
+import threading
+import unittest
+from base64 import b64encode
+from datetime import datetime
+from urllib.parse import urlparse
+
+from darabonba.request import DaraRequest
+from darabonba.runtime import RuntimeOptions
+from darabonba.websocket import (
+    AbstractWebSocketHandler,
+    DefaultWebSocketClient,
+    WebSocketMessage,
+    WebSocketMessageType,
+    WebSocketSessionInfo,
+    build_websocket_url,
+    convert_to_websocket_message_type,
+    new_default_websocket_client,
+    new_websocket_client_and_connect,
+)
+
+
+WEBSOCKET_GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11'
+
+
+class MockWebSocketHandler(AbstractWebSocketHandler):
+    def __init__(self):
+        self.connected_called = False
+        self.message_received_count = 0
+        self.error_count = 0
+        self.closed_called = False
+        self.last_message = None
+
+    def after_connection_established(self, session):
+        self.connected_called = True
+
+    def handle_raw_message(self, session, message):
+        self.message_received_count += 1
+        self.last_message = message
+
+    def handle_error(self, session, err):
+        self.error_count += 1
+
+    def after_connection_closed(self, session, code, reason):
+        self.closed_called = True
+
+
+class ErrorOnConnectHandler(MockWebSocketHandler):
+    def after_connection_established(self, session):
+        raise Exception('test error on connection')
+
+
+class SimpleEchoWebSocketServer:
+    def __init__(self):
+        self._server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._server.bind(('127.0.0.1', 0))
+        self.port = self._server.getsockname()[1]
+        self._server.listen(5)
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    def _serve(self):
+        self._server.settimeout(0.5)
+        while not self._stop.is_set():
+            try:
+                conn, _addr = self._server.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            threading.Thread(target=self._handle_client, args=(conn,), daemon=True).start()
+
+    def _handle_client(self, conn):
+        try:
+            request = conn.recv(4096).decode('utf-8', errors='ignore')
+            key = None
+            for line in request.split('\r\n'):
+                if line.lower().startswith('sec-websocket-key:'):
+                    key = line.split(':', 1)[1].strip()
+            if not key:
+                conn.close()
+                return
+            accept = b64encode(hashlib.sha1((key + WEBSOCKET_GUID).encode()).digest()).decode()
+            response = (
+                'HTTP/1.1 101 Switching Protocols\r\n'
+                'Upgrade: websocket\r\n'
+                'Connection: Upgrade\r\n'
+                f'Sec-WebSocket-Accept: {accept}\r\n'
+                'X-Acs-Ws-Session-Id: test-session-id\r\n'
+                '\r\n'
+            )
+            conn.sendall(response.encode())
+
+            while not self._stop.is_set():
+                try:
+                    header = conn.recv(2)
+                    if len(header) < 2:
+                        break
+                    length = header[1] & 127
+                    if length == 126:
+                        length = struct.unpack('>H', conn.recv(2))[0]
+                    elif length == 127:
+                        length = struct.unpack('>Q', conn.recv(8))[0]
+                    masked = header[1] & 128
+                    mask = conn.recv(4) if masked else b''
+                    payload = conn.recv(length)
+                    if masked:
+                        payload = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+                    frame = self._encode_text_frame(payload)
+                    conn.sendall(frame)
+                except OSError:
+                    break
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _encode_text_frame(payload):
+        length = len(payload)
+        if length <= 125:
+            header = struct.pack('>BB', 0x81, length)
+        elif length <= 65535:
+            header = struct.pack('>BBH', 0x81, 126, length)
+        else:
+            header = struct.pack('>BBQ', 0x81, 127, length)
+        return header + payload
+
+    def close(self):
+        self._stop.set()
+        try:
+            self._server.close()
+        except OSError:
+            pass
+        self._thread.join(timeout=2)
+
+
+class TestWebSocket(unittest.TestCase):
+    def test_create_default_websocket_client(self):
+        handler = MockWebSocketHandler()
+        client = new_default_websocket_client(handler)
+        self.assertIsNotNone(client)
+        self.assertFalse(client.is_connected())
+        with self.assertRaisesRegex(ValueError, 'handler cannot be nil'):
+            new_default_websocket_client(None)
+
+    def test_websocket_message_type_values(self):
+        self.assertEqual(WebSocketMessageType.Text, 0)
+        self.assertEqual(WebSocketMessageType.Binary, 1)
+
+    def test_convert_websocket_message_type(self):
+        self.assertEqual(convert_to_websocket_message_type(1), WebSocketMessageType.Text)
+        self.assertEqual(convert_to_websocket_message_type(2), WebSocketMessageType.Binary)
+        self.assertEqual(convert_to_websocket_message_type(9), WebSocketMessageType.Ping)
+        self.assertEqual(convert_to_websocket_message_type(10), WebSocketMessageType.Pong)
+        self.assertEqual(convert_to_websocket_message_type(8), WebSocketMessageType.Close)
+        self.assertEqual(convert_to_websocket_message_type(999), WebSocketMessageType.Binary)
+
+    def test_mock_handler_callbacks(self):
+        handler = MockWebSocketHandler()
+        session = WebSocketSessionInfo(session_id='test')
+        handler.after_connection_established(session)
+        self.assertTrue(handler.connected_called)
+
+        msg = WebSocketMessage(
+            type=WebSocketMessageType.Text,
+            payload=b'test message',
+            headers={},
+            timestamp=datetime.now(),
+        )
+        handler.handle_raw_message(session, msg)
+        handler.handle_raw_message(session, msg)
+        self.assertEqual(2, handler.message_received_count)
+        self.assertEqual(b'test message', handler.last_message.payload)
+
+        handler.handle_error(session, Exception('test'))
+        self.assertEqual(1, handler.error_count)
+
+        handler.after_connection_closed(session, 1000, 'Normal')
+        self.assertTrue(handler.closed_called)
+
+    def test_build_websocket_url(self):
+        request = DaraRequest()
+        request.protocol = 'ws'
+        request.headers = {'host': 'example.com'}
+        request.pathname = '/path'
+        request.query = {'foo': 'bar'}
+        url = build_websocket_url(request)
+        self.assertEqual('ws://example.com/path?foo=bar', url)
+
+    def test_connect_success(self):
+        server = SimpleEchoWebSocketServer()
+        try:
+            request = DaraRequest()
+            request.protocol = 'ws'
+            request.domain = f'127.0.0.1:{server.port}'
+            request.pathname = '/'
+            request.headers = {'host': f'127.0.0.1:{server.port}'}
+
+            runtime = RuntimeOptions(
+                connect_timeout=5000,
+                read_timeout=30000,
+                web_socket_ping_interval=0,
+                web_socket_enable_reconnect=False,
+            )
+            handler = MockWebSocketHandler()
+            client = new_default_websocket_client(handler)
+            response = client.connect(request, runtime)
+
+            self.assertIsNotNone(response)
+            self.assertTrue(client.is_connected())
+            self.assertTrue(handler.connected_called)
+            self.assertEqual('test-session-id', client.session.session_id)
+            client.disconnect()
+        finally:
+            server.close()
+
+    def test_connect_missing_domain(self):
+        request = DaraRequest()
+        request.protocol = 'ws'
+        request.headers = {}
+        runtime = RuntimeOptions(connect_timeout=5000)
+        client = new_default_websocket_client(MockWebSocketHandler())
+        with self.assertRaisesRegex(ValueError, 'domain is required'):
+            client.connect(request, runtime)
+
+    def test_connect_timeout(self):
+        request = DaraRequest()
+        request.protocol = 'ws'
+        request.domain = '127.0.0.1:59999'
+        request.pathname = '/'
+        request.headers = {'host': '127.0.0.1:59999'}
+        runtime = RuntimeOptions(
+            connect_timeout=100,
+            web_socket_handshake_timeout=100,
+        )
+        handler = MockWebSocketHandler()
+        client = new_default_websocket_client(handler)
+        with self.assertRaises(Exception):
+            client.connect(request, runtime)
+        self.assertFalse(client.is_connected())
+        self.assertFalse(handler.connected_called)
+
+    def test_handler_error_on_connect(self):
+        server = SimpleEchoWebSocketServer()
+        try:
+            request = DaraRequest()
+            request.protocol = 'ws'
+            request.domain = f'127.0.0.1:{server.port}'
+            request.pathname = '/'
+            request.headers = {'host': f'127.0.0.1:{server.port}'}
+            runtime = RuntimeOptions(
+                connect_timeout=5000,
+                web_socket_ping_interval=0,
+            )
+            client = new_default_websocket_client(ErrorOnConnectHandler())
+            with self.assertRaisesRegex(Exception, 'test error on connection'):
+                client.connect(request, runtime)
+            client.disconnect()
+        finally:
+            server.close()
+
+    def test_send_text_echo(self):
+        server = SimpleEchoWebSocketServer()
+        try:
+            request = DaraRequest()
+            request.protocol = 'ws'
+            request.domain = f'127.0.0.1:{server.port}'
+            request.pathname = '/'
+            request.headers = {'host': f'127.0.0.1:{server.port}'}
+            handler = MockWebSocketHandler()
+            runtime = RuntimeOptions(
+                connect_timeout=5000,
+                web_socket_ping_interval=0,
+                web_socket_enable_reconnect=False,
+                web_socket_handler=handler,
+            )
+            client, _response = new_websocket_client_and_connect(request, runtime)
+            client.send_text('hello')
+            import time
+            time.sleep(0.2)
+            self.assertGreaterEqual(handler.message_received_count, 1)
+            client.close()
+        finally:
+            server.close()
+
+    def test_reconnect_when_already_connected(self):
+        server = SimpleEchoWebSocketServer()
+        try:
+            request = DaraRequest()
+            request.protocol = 'ws'
+            request.domain = f'127.0.0.1:{server.port}'
+            request.pathname = '/'
+            request.headers = {'host': f'127.0.0.1:{server.port}'}
+            handler = MockWebSocketHandler()
+            runtime = RuntimeOptions(
+                web_socket_enable_reconnect=True,
+                web_socket_max_reconnect_times=3,
+                web_socket_reconnect_interval=100,
+                web_socket_handshake_timeout=5000,
+                web_socket_ping_interval=0,
+                web_socket_handler=handler,
+            )
+            client, _response = new_websocket_client_and_connect(request, runtime)
+            self.assertTrue(client.is_connected())
+            with self.assertRaisesRegex(Exception, 'already connected'):
+                client.reconnect()
+            client.close()
+        finally:
+            server.close()
+
+    def test_configure_tls(self):
+        client = DefaultWebSocketClient(MockWebSocketHandler())
+        ignore_ssl = client.configure_tls(RuntimeOptions(ignore_ssl=True), 'wss')
+        self.assertEqual(ssl.CERT_NONE, ignore_ssl['cert_reqs'])
+        verify_ssl = client.configure_tls(RuntimeOptions(ignore_ssl=False), 'wss')
+        self.assertEqual(ssl.CERT_REQUIRED, verify_ssl['cert_reqs'])
+
+    def test_configure_http_proxy(self):
+        client = DefaultWebSocketClient(MockWebSocketHandler())
+        parsed = urlparse('wss://example.com/ws')
+        request = DaraRequest()
+        request.headers = {}
+        proxy_kwargs = client.configure_http_proxy(
+            parsed,
+            RuntimeOptions(https_proxy='http://proxy.example.com:8080'),
+            request,
+        )
+        self.assertEqual('proxy.example.com', proxy_kwargs['http_proxy_host'])
+
+        no_proxy_kwargs = client.configure_http_proxy(
+            parsed,
+            RuntimeOptions(https_proxy='http://proxy.example.com:8080', no_proxy='example.com'),
+            request,
+        )
+        self.assertEqual({}, no_proxy_kwargs)
+
+        auth_request = DaraRequest()
+        auth_request.headers = {}
+        auth_kwargs = client.configure_http_proxy(
+            parsed,
+            RuntimeOptions(https_proxy='http://user:pass@proxy.example.com:8080'),
+            auth_request,
+        )
+        self.assertIn('Proxy-Authorization', auth_request.headers)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -347,6 +347,145 @@ class TestWebSocket(unittest.TestCase):
         )
         self.assertIn('Proxy-Authorization', auth_request.headers)
 
+    def test_no_duplicate_sec_websocket_protocol_header(self):
+        # Intercept WebSocketApp to capture what headers and subprotocols are passed.
+        captured = {}
+        original_init = __import__('websocket').WebSocketApp.__init__
+
+        def patched_init(self_app, url, header=None, on_open=None,
+                         on_message=None, on_error=None, on_close=None,
+                         subprotocols=None, **kwargs):
+            captured['header'] = header
+            captured['subprotocols'] = subprotocols
+            raise ConnectionRefusedError('captured')
+
+        import websocket as ws_lib
+        ws_lib.WebSocketApp.__init__ = patched_init
+        try:
+            # Simulate the real call path: openapi client pre-sets
+            # 'sec-websocket-protocol' in request.headers for ACS3 signature.
+            request = DaraRequest()
+            request.protocol = 'ws'
+            request.domain = '127.0.0.1:19999'
+            request.pathname = '/'
+            request.headers = {
+                'host': '127.0.0.1:19999',
+                'sec-websocket-protocol': 'awap',
+            }
+
+            runtime = RuntimeOptions(
+                connect_timeout=5000,
+                read_timeout=5000,
+                web_socket_ping_interval=0,
+                web_socket_enable_reconnect=False,
+                websocket_sub_protocol='awap',
+            )
+            handler = MockWebSocketHandler()
+            client = new_default_websocket_client(handler)
+            try:
+                client.connect(request, runtime)
+            except (ConnectionRefusedError, Exception):
+                pass
+
+            header = captured.get('header', {})
+
+            # Must have exactly 1 key matching 'sec-websocket-protocol' (case-insensitive).
+            # Before fix: Python dict had both 'sec-websocket-protocol' and
+            # 'Sec-WebSocket-Protocol' because dict keys are case-sensitive.
+            protocol_keys = [k for k in header if k.lower() == 'sec-websocket-protocol']
+            self.assertEqual(1, len(protocol_keys),
+                             f'Expected 1 protocol header key, got: {protocol_keys}')
+
+            # subprotocols must be None. If set to ['awap'], websocket-client
+            # library merges it with the header into 'awap,awap' on the wire.
+            self.assertIsNone(captured.get('subprotocols'))
+        finally:
+            ws_lib.WebSocketApp.__init__ = original_init
+
+    def test_subprotocols_not_passed_even_without_preset_header(self):
+        # Even when request.headers does NOT contain sec-websocket-protocol,
+        # subprotocols param must still be None to avoid duplication.
+        captured = {}
+        original_init = __import__('websocket').WebSocketApp.__init__
+
+        def patched_init(self_app, url, header=None, on_open=None,
+                         on_message=None, on_error=None, on_close=None,
+                         subprotocols=None, **kwargs):
+            captured['header'] = header
+            captured['subprotocols'] = subprotocols
+            raise ConnectionRefusedError('captured')
+
+        import websocket as ws_lib
+        ws_lib.WebSocketApp.__init__ = patched_init
+        try:
+            request = DaraRequest()
+            request.protocol = 'ws'
+            request.domain = '127.0.0.1:19999'
+            request.pathname = '/'
+            request.headers = {'host': '127.0.0.1:19999'}
+
+            runtime = RuntimeOptions(
+                connect_timeout=5000,
+                read_timeout=5000,
+                web_socket_ping_interval=0,
+                web_socket_enable_reconnect=False,
+                websocket_sub_protocol='general',
+            )
+            handler = MockWebSocketHandler()
+            client = new_default_websocket_client(handler)
+            try:
+                client.connect(request, runtime)
+            except (ConnectionRefusedError, Exception):
+                pass
+
+            # subprotocols must always be None regardless of input.
+            self.assertIsNone(captured.get('subprotocols'))
+        finally:
+            ws_lib.WebSocketApp.__init__ = original_init
+
+    def test_protocol_header_value_preserved_from_request(self):
+        # The header value from request.headers must pass through unchanged.
+        captured = {}
+        original_init = __import__('websocket').WebSocketApp.__init__
+
+        def patched_init(self_app, url, header=None, on_open=None,
+                         on_message=None, on_error=None, on_close=None,
+                         subprotocols=None, **kwargs):
+            captured['header'] = header
+            raise ConnectionRefusedError('captured')
+
+        import websocket as ws_lib
+        ws_lib.WebSocketApp.__init__ = patched_init
+        try:
+            request = DaraRequest()
+            request.protocol = 'ws'
+            request.domain = '127.0.0.1:19999'
+            request.pathname = '/'
+            request.headers = {
+                'host': '127.0.0.1:19999',
+                'sec-websocket-protocol': 'general',
+            }
+
+            runtime = RuntimeOptions(
+                connect_timeout=5000,
+                read_timeout=5000,
+                web_socket_ping_interval=0,
+                web_socket_enable_reconnect=False,
+                websocket_sub_protocol='general',
+            )
+            handler = MockWebSocketHandler()
+            client = new_default_websocket_client(handler)
+            try:
+                client.connect(request, runtime)
+            except (ConnectionRefusedError, Exception):
+                pass
+
+            header = captured.get('header', {})
+            # Value must be exactly 'general', not 'general,general'
+            self.assertEqual('general', header.get('sec-websocket-protocol'))
+        finally:
+            ws_lib.WebSocketApp.__init__ = original_init
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- Add `darabonba/websocket.py` with `DefaultWebSocketClient`, `WebSocketHandler`, and runtime helper getters aligned with Go/TypeScript.
- Extend `RuntimeOptions` with WebSocket fields (snake_case model, camelCase runtime dict keys).
- Add `websocket-client` dependency and integration tests with a threaded echo mock server.

## Test plan
- [x] `pip install -e . && pytest` — 239 passed (13 new WebSocket tests)