### PR TITLE
fix: honor maxIdleConns for HTTP connection pool size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,18 +23,34 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: pip install yarl==1.9.4 multidict==6.0.5 aiohttp==3.8.6 pytest==6.2.5 coverage==5.5 importlib-metadata==1.7.0 zipp==2.2.1 typing-extensions && python setup.py install
+    - name: Install dependencies (3.7)
       if: matrix.python-version == '3.7'
-    - name: Install dependencies
-      run: pip install yarl==1.15.2 pytest coverage aiohttp==3.8.6 && python setup.py install
+      run: |
+        python -m pip install -U 'pip<24.1' 'setuptools<68' wheel
+        python -m pip install 'yarl==1.9.4' 'multidict==6.0.5' 'aiohttp==3.8.6' \
+          'pytest==6.2.5' 'coverage==5.5' 'importlib-metadata==1.7.0' 'zipp==2.2.1' \
+          'typing-extensions' 'websocket-client>=1.6.0,<1.8.0' 'requests>=2.21.0,<2.32.0'
+        python -m pip install -e .
+    - name: Install dependencies (3.8)
       if: matrix.python-version == '3.8'
-    - name: Install dependencies
-      run: python -m pip install setuptools && python setup.py install && pip install pytest coverage
-      if: matrix.python-version != '3.7' && matrix.python-version != '3.8'
-    - name: Install dependencies
-      run: python -m pip install setuptools alibabacloud-tea && python setup.py install && pip install pytest coverage
-      if: matrix.python-version == '3.12'
+      run: |
+        python -m pip install -U 'pip<25' 'setuptools<75' wheel
+        python -m pip install 'yarl==1.15.2' 'aiohttp==3.8.6' \
+          'pytest' 'coverage' 'websocket-client>=1.6.0,<1.8.0' 'requests>=2.21.0,<2.32.0'
+        python -m pip install -e .
+    - name: Install dependencies (3.9)
+      if: matrix.python-version == '3.9'
+      run: |
+        python -m pip install -U pip setuptools wheel
+        python -m pip install 'aiohttp>=3.7.0,<3.11.0' 'requests>=2.21.0,<2.32.0' \
+          'pytest' 'coverage'
+        python -m pip install -e .
+    - name: Install dependencies (3.10+)
+      if: matrix.python-version != '3.7' && matrix.python-version != '3.8' && matrix.python-version != '3.9'
+      run: |
+        python -m pip install -U pip setuptools wheel
+        python -m pip install -e .
+        python -m pip install pytest coverage
     - name: Test with unittest
       run: |
         coverage run --source="./darabonba" -m pytest tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     branches: [ master ]
   schedule:
     - cron:  '0 8 * * *'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,6 @@
+### 2026-07-13 Version 1.0.9
+* Honor RuntimeOptions.maxIdleConns for urllib3 / aiohttp connection pool size (#100).
+
 ### 2026-07-10 Version 1.0.8
 * Support WebSocket client.
 

--- a/darabonba/core.py
+++ b/darabonba/core.py
@@ -24,6 +24,7 @@ from darabonba.policy.retry import RetryOptions, RetryPolicyContext
 DEFAULT_CONNECT_TIMEOUT = 5000
 DEFAULT_READ_TIMEOUT = 10000
 DEFAULT_POOL_SIZE = 10
+DEFAULT_POOL_MAXSIZE = DEFAULT_POOL_SIZE * 4
 MAX_DELAY_TIME = 120 * 1000
 MIN_DELAY_TIME = 100
 
@@ -61,8 +62,8 @@ class _TLSAdapter(adapters.HTTPAdapter):
 
 class DaraCore:
     _sessions = {}
-    http_adapter = adapters.HTTPAdapter(pool_connections=DEFAULT_POOL_SIZE, pool_maxsize=DEFAULT_POOL_SIZE * 4)
-    https_adapter = adapters.HTTPAdapter(pool_connections=DEFAULT_POOL_SIZE, pool_maxsize=DEFAULT_POOL_SIZE * 4)
+    http_adapter = adapters.HTTPAdapter(pool_connections=DEFAULT_POOL_SIZE, pool_maxsize=DEFAULT_POOL_MAXSIZE)
+    https_adapter = adapters.HTTPAdapter(pool_connections=DEFAULT_POOL_SIZE, pool_maxsize=DEFAULT_POOL_MAXSIZE)
 
     @staticmethod
     def to_json_string(
@@ -79,6 +80,24 @@ class DaraCore:
         )
 
     @staticmethod
+    def _resolve_pool_maxsize(runtime_option=None) -> int:
+        """
+        Resolve urllib3 / aiohttp pool size from runtime maxIdleConns.
+        Aligns with Go tea: MaxIdleConns / MaxIdleConnsPerHost.
+        """
+        runtime_option = runtime_option or {}
+        max_idle = runtime_option.get('maxIdleConns')
+        if max_idle is None:
+            return DEFAULT_POOL_MAXSIZE
+        try:
+            max_idle = int(max_idle)
+        except (TypeError, ValueError):
+            return DEFAULT_POOL_MAXSIZE
+        if max_idle > 0:
+            return max_idle
+        return DEFAULT_POOL_MAXSIZE
+
+    @staticmethod
     def _set_tls_minimum_version(sls_context, tls_min_version):
         context = sls_context
         if tls_min_version is not None:
@@ -93,14 +112,18 @@ class DaraCore:
         return context
     
     @staticmethod
-    def get_adapter(prefix, tls_min_version: str = None):
+    def get_adapter(prefix, tls_min_version: str = None, pool_size: int = None):
+        pool_maxsize = pool_size if pool_size is not None and pool_size > 0 else DEFAULT_POOL_MAXSIZE
         ca_cert = certifi.where()
         context = ssl.create_default_context()
         if ca_cert and prefix.upper() == 'HTTPS':
             context = DaraCore._set_tls_minimum_version(context, tls_min_version)
             context.load_verify_locations(ca_cert)
-        adapter = _TLSAdapter(ssl_context=context, pool_connections=DEFAULT_POOL_SIZE,
-                              pool_maxsize=DEFAULT_POOL_SIZE * 4)
+        adapter = _TLSAdapter(
+            ssl_context=context,
+            pool_connections=DEFAULT_POOL_SIZE,
+            pool_maxsize=pool_maxsize,
+        )
         return adapter
 
     @staticmethod
@@ -194,6 +217,7 @@ class DaraCore:
             if not proxy:
                 proxy = os.environ.get('HTTPS_PROXY') or os.environ.get('https_proxy')
 
+        pool_maxsize = DaraCore._resolve_pool_maxsize(runtime_option)
         connector = None
         ca_cert = certifi.where()
         ssl_context = None
@@ -207,7 +231,9 @@ class DaraCore:
                     ssl_context.load_cert_chain(certfile=cert[0], keyfile=cert[1] if len(cert) > 1 else None)
                 else:
                     ssl_context.load_cert_chain(certfile=cert, keyfile=None)
-            connector = aiohttp.TCPConnector(ssl=ssl_context)
+            connector = aiohttp.TCPConnector(
+                ssl=ssl_context, limit=pool_maxsize, limit_per_host=pool_maxsize
+            )
         elif ca_cert and request.protocol.upper() == 'HTTPS' and verify:
             ssl_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
             ssl_context = DaraCore._set_tls_minimum_version(ssl_context, tls_min_version)
@@ -218,9 +244,12 @@ class DaraCore:
                     ssl_context.load_cert_chain(certfile=cert[0], keyfile=cert[1] if len(cert) > 1 else None)
                 else:
                     ssl_context.load_cert_chain(certfile=cert, keyfile=None)
-            connector = aiohttp.TCPConnector(ssl=ssl_context)
+            connector = aiohttp.TCPConnector(
+                ssl=ssl_context, limit=pool_maxsize, limit_per_host=pool_maxsize
+            )
         else:
             verify = False
+            connector = aiohttp.TCPConnector(limit=pool_maxsize, limit_per_host=pool_maxsize)
 
         timeout = aiohttp.ClientTimeout(
             sock_read=read_timeout,
@@ -310,9 +339,11 @@ class DaraCore:
         host = request.headers.get('host')
         host = host.rstrip('/')
 
-        session_key = f'{request.protocol.lower()}://{host}:{request.port}'
+        pool_maxsize = DaraCore._resolve_pool_maxsize(runtime_option)
+        session_key = f'{request.protocol.lower()}://{host}:{request.port}:pool={pool_maxsize}'
         session = DaraCore._get_session(session_key=session_key, protocol=request.protocol,
-                                       tls_min_version=tls_min_version, verify=verify)
+                                       tls_min_version=tls_min_version, verify=verify,
+                                       pool_size=pool_maxsize)
         try:
             resp = session.send(
                 p,
@@ -374,6 +405,7 @@ class DaraCore:
             if not proxy:
                 proxy = os.environ.get('HTTPS_PROXY') or os.environ.get('https_proxy')
 
+        pool_maxsize = DaraCore._resolve_pool_maxsize(runtime_option)
         connector = None
         ca_cert = certifi.where()
         ssl_context = None
@@ -387,7 +419,9 @@ class DaraCore:
                     ssl_context.load_cert_chain(certfile=cert[0], keyfile=cert[1] if len(cert) > 1 else None)
                 else:
                     ssl_context.load_cert_chain(certfile=cert, keyfile=None)
-            connector = aiohttp.TCPConnector(ssl=ssl_context)
+            connector = aiohttp.TCPConnector(
+                ssl=ssl_context, limit=pool_maxsize, limit_per_host=pool_maxsize
+            )
         elif ca_cert and request.protocol.upper() == 'HTTPS' and verify:
             ssl_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
             ssl_context = DaraCore._set_tls_minimum_version(ssl_context, tls_min_version)
@@ -398,9 +432,12 @@ class DaraCore:
                     ssl_context.load_cert_chain(certfile=cert[0], keyfile=cert[1] if len(cert) > 1 else None)
                 else:
                     ssl_context.load_cert_chain(certfile=cert, keyfile=None)
-            connector = aiohttp.TCPConnector(ssl=ssl_context)
+            connector = aiohttp.TCPConnector(
+                ssl=ssl_context, limit=pool_maxsize, limit_per_host=pool_maxsize
+            )
         else:
             verify = False
+            connector = aiohttp.TCPConnector(limit=pool_maxsize, limit_per_host=pool_maxsize)
 
         timeout = aiohttp.ClientTimeout(
             sock_read=read_timeout,
@@ -496,9 +533,11 @@ class DaraCore:
         host = request.headers.get('host')
         host = host.rstrip('/') if host else ''
 
-        session_key = f'{request.protocol.lower()}://{host}:{request.port}'
+        pool_maxsize = DaraCore._resolve_pool_maxsize(runtime_option)
+        session_key = f'{request.protocol.lower()}://{host}:{request.port}:pool={pool_maxsize}'
         session = DaraCore._get_session(session_key=session_key, protocol=request.protocol,
-                                    tls_min_version=tls_min_version, verify=verify)
+                                    tls_min_version=tls_min_version, verify=verify,
+                                    pool_size=pool_maxsize)
         try:
             resp = session.send(
                 p,
@@ -652,15 +691,21 @@ class DaraCore:
             return model
 
     @staticmethod
-    def _get_session(session_key: str, protocol: str, tls_min_version: str = None, verify: bool = True):
+    def _get_session(session_key: str, protocol: str, tls_min_version: str = None,
+                     verify: bool = True, pool_size: int = None):
         if session_key not in DaraCore._sessions:
             session = Session()
-            adapter = DaraCore.get_adapter(protocol, tls_min_version)
+            adapter = DaraCore.get_adapter(protocol, tls_min_version, pool_size=pool_size)
             if protocol.upper() == 'HTTPS':
                 if verify:
                     session.mount('https://', adapter)
                 else:
-                    session.mount('https://', DaraCore.https_adapter)
+                    # Honor configured pool size even when SSL verify is disabled.
+                    insecure_adapter = adapters.HTTPAdapter(
+                        pool_connections=DEFAULT_POOL_SIZE,
+                        pool_maxsize=pool_size if pool_size is not None and pool_size > 0 else DEFAULT_POOL_MAXSIZE,
+                    )
+                    session.mount('https://', insecure_adapter)
             else:
                 session.mount('http://', adapter)
             DaraCore._sessions[session_key] = session

--- a/setup.py
+++ b/setup.py
@@ -29,19 +29,26 @@ install_requires = [
     'alibabacloud-tea'
 ]
 
+# Pin transitive deps for older CPython: recent requests/aiohttp/websocket-client
+# use PEP604 unions / builtin generics that break import on 3.7–3.9.
 if sys.version_info.minor <= 7:
     install_requires.append('requests>=2.21.0, <2.32.0')
     install_requires.append('aiohttp>=3.7.0, <3.9.0')
     install_requires.append('urllib3<2.0.7')
+    install_requires.append('websocket-client>=1.6.0, <1.8.0')
 elif sys.version_info.minor <= 8:
-    install_requires.append('requests>=2.21.0, <3.0.0')
+    install_requires.append('requests>=2.21.0, <2.32.0')
     install_requires.append('aiohttp>=3.7.0, <3.11.0')
     install_requires.append('urllib3<2.3.0')
+    install_requires.append('websocket-client>=1.6.0, <1.8.0')
+elif sys.version_info.minor <= 9:
+    install_requires.append('requests>=2.21.0, <2.32.0')
+    install_requires.append('aiohttp>=3.7.0, <3.11.0')
+    install_requires.append('websocket-client>=1.6.0, <2.0.0')
 else:
     install_requires.append('requests>=2.21.0, <3.0.0')
     install_requires.append('aiohttp>=3.7.0, <4.0.0')
-
-install_requires.append('websocket-client>=1.6.0, <2.0.0')
+    install_requires.append('websocket-client>=1.6.0, <2.0.0')
 
 if ssl.OPENSSL_VERSION_INFO is not None and len(ssl.OPENSSL_VERSION_INFO) >= 3 and ssl.OPENSSL_VERSION_INFO[:3] >= (
         1, 1, 1):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -18,7 +18,10 @@ except ImportError:
             return super(AsyncMock, self).__call__(*args, **kwargs)
 
 from darabonba.utils.stream import BaseStream, SyncSSEResponseWrapper, SSEResponseWrapper
-from darabonba.core import DaraCore, _TLSAdapter, TLSVersion, _ModelEncoder
+from darabonba.core import (
+    DaraCore, _TLSAdapter, TLSVersion, _ModelEncoder,
+    DEFAULT_POOL_SIZE, DEFAULT_POOL_MAXSIZE,
+)
 from darabonba.exceptions import RetryError, DaraException
 from darabonba.model import DaraModel
 from darabonba.request import DaraRequest
@@ -433,6 +436,33 @@ class TestCore(unittest.TestCase):
             self.assertEqual(result.status_code, 200)
             self.assertEqual(result.status_message, 'OK')
             self.assertEqual(result.body, b'{"result": "test"}')
+
+    def test_do_action_passes_max_idle_conns(self):
+        """Runtime maxIdleConns must be forwarded to session pool size."""
+        request = DaraRequest()
+        request.headers['host'] = "openapi.aligenie.com"
+        request.pathname = "/"
+        request.protocol = "https"
+
+        mock_session = Mock()
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.reason = 'OK'
+        mock_response.headers = {}
+        mock_response.content = b'ok'
+        mock_session.send.return_value = mock_response
+
+        with patch('darabonba.core.DaraCore._get_session', return_value=mock_session) as mock_get_session:
+            DaraCore.do_action(request, {"maxIdleConns": 128})
+            kwargs = mock_get_session.call_args[1]
+            self.assertEqual(128, kwargs['pool_size'])
+            self.assertIn(':pool=128', kwargs['session_key'])
+
+        with patch('darabonba.core.DaraCore._get_session', return_value=mock_session) as mock_get_session:
+            DaraCore.do_action(request, {})
+            kwargs = mock_get_session.call_args[1]
+            self.assertEqual(DEFAULT_POOL_MAXSIZE, kwargs['pool_size'])
+            self.assertIn(f':pool={DEFAULT_POOL_MAXSIZE}', kwargs['session_key'])
 
     def test_do_action(self):
         request = DaraRequest()
@@ -1063,15 +1093,17 @@ class TestCore(unittest.TestCase):
         request = DaraRequest()
         request.headers['host'] = "127.0.0.1:9999"
         request.protocol = "https"
-        session_key = f'{request.protocol.lower()}://{request.headers["host"]}:{request.port}'
+        session_key = f'{request.protocol.lower()}://{request.headers["host"]}:{request.port}:pool={DEFAULT_POOL_MAXSIZE}'
 
         # Test with TLSv1.2
         with patch('darabonba.core.DaraCore.get_adapter') as mock_get_adapter:
             mock_adapter = Mock()
             mock_get_adapter.return_value = mock_adapter
 
-            session = DaraCore._get_session(session_key, request.protocol, 'TLSv1.2')
-            mock_get_adapter.assert_called_once_with(request.protocol, 'TLSv1.2')
+            session = DaraCore._get_session(session_key, request.protocol, 'TLSv1.2',
+                                           pool_size=DEFAULT_POOL_MAXSIZE)
+            mock_get_adapter.assert_called_once_with(request.protocol, 'TLSv1.2',
+                                                     pool_size=DEFAULT_POOL_MAXSIZE)
             self.assertIn(session_key, DaraCore._sessions)
             self.assertEqual(session, DaraCore._sessions[session_key])
 
@@ -1080,21 +1112,24 @@ class TestCore(unittest.TestCase):
             mock_adapter = Mock()
             mock_get_adapter.return_value = mock_adapter
 
-            session = DaraCore._get_session(session_key, request.protocol, 'TLSv1.3')
+            session = DaraCore._get_session(session_key, request.protocol, 'TLSv1.3',
+                                           pool_size=DEFAULT_POOL_MAXSIZE)
             mock_get_adapter.assert_not_called()  # Should not call get_adapter again
             self.assertIn(session_key, DaraCore._sessions)
             self.assertEqual(session, DaraCore._sessions[session_key])
 
         # Test with HTTP protocol
         request.protocol = "http"
-        session_key = f'{request.protocol.lower()}://{request.headers["host"]}:{request.port}'
+        session_key = f'{request.protocol.lower()}://{request.headers["host"]}:{request.port}:pool={DEFAULT_POOL_MAXSIZE}'
 
         with patch('darabonba.core.DaraCore.get_adapter') as mock_get_adapter:
             mock_adapter = Mock()
             mock_get_adapter.return_value = mock_adapter
 
-            session = DaraCore._get_session(session_key, request.protocol, 'TLSv1.2')
-            mock_get_adapter.assert_called_once_with(request.protocol, 'TLSv1.2')
+            session = DaraCore._get_session(session_key, request.protocol, 'TLSv1.2',
+                                           pool_size=DEFAULT_POOL_MAXSIZE)
+            mock_get_adapter.assert_called_once_with(request.protocol, 'TLSv1.2',
+                                                     pool_size=DEFAULT_POOL_MAXSIZE)
             self.assertIn(session_key, DaraCore._sessions)
             self.assertEqual(session, DaraCore._sessions[session_key])
 
@@ -1103,10 +1138,43 @@ class TestCore(unittest.TestCase):
             mock_adapter = Mock()
             mock_get_adapter.return_value = mock_adapter
 
-            session = DaraCore._get_session(session_key, request.protocol, 'TLSv1.2')
+            session = DaraCore._get_session(session_key, request.protocol, 'TLSv1.2',
+                                           pool_size=DEFAULT_POOL_MAXSIZE)
             mock_get_adapter.assert_not_called()  # Should not call get_adapter again
             self.assertIn(session_key, DaraCore._sessions)
             self.assertEqual(session, DaraCore._sessions[session_key])
+
+    def test_resolve_pool_maxsize(self):
+        self.assertEqual(DEFAULT_POOL_MAXSIZE, DaraCore._resolve_pool_maxsize(None))
+        self.assertEqual(DEFAULT_POOL_MAXSIZE, DaraCore._resolve_pool_maxsize({}))
+        self.assertEqual(DEFAULT_POOL_MAXSIZE, DaraCore._resolve_pool_maxsize({'maxIdleConns': 0}))
+        self.assertEqual(DEFAULT_POOL_MAXSIZE, DaraCore._resolve_pool_maxsize({'maxIdleConns': -1}))
+        self.assertEqual(DEFAULT_POOL_MAXSIZE, DaraCore._resolve_pool_maxsize({'maxIdleConns': 'bad'}))
+        self.assertEqual(100, DaraCore._resolve_pool_maxsize({'maxIdleConns': 100}))
+        self.assertEqual(50, DaraCore._resolve_pool_maxsize({'maxIdleConns': '50'}))
+
+    def test_get_adapter_respects_pool_size(self):
+        adapter = DaraCore.get_adapter('https', 'TLSv1.2', pool_size=128)
+        self.assertEqual(128, adapter._pool_maxsize)
+        self.assertEqual(DEFAULT_POOL_SIZE, adapter._pool_connections)
+
+        default_adapter = DaraCore.get_adapter('https', 'TLSv1.2')
+        self.assertEqual(DEFAULT_POOL_MAXSIZE, default_adapter._pool_maxsize)
+
+    def test_get_session_uses_custom_pool_size(self):
+        DaraCore._sessions.clear()
+        session_key = 'https://openapi.aligenie.com:80:pool=128'
+        session = DaraCore._get_session(session_key, 'https', 'TLSv1.2',
+                                       verify=True, pool_size=128)
+        adapter = session.get_adapter('https://openapi.aligenie.com/')
+        self.assertEqual(128, adapter._pool_maxsize)
+        # Different pool size should create a separate session
+        other_key = 'https://openapi.aligenie.com:80:pool=40'
+        other = DaraCore._get_session(other_key, 'https', 'TLSv1.2',
+                                     verify=True, pool_size=40)
+        self.assertIsNot(session, other)
+        self.assertEqual(40, other.get_adapter('https://openapi.aligenie.com/')._pool_maxsize)
+        DaraCore._sessions.clear()
 
 class TestGetBackoffTime(unittest.TestCase):
     def setUp(self):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -150,3 +150,38 @@ class TestTypeCheckDecorator(unittest.TestCase):
             self.assertEqual(len(w), 1)
             self.assertTrue(issubclass(w[-1].category, UserWarning))
 
+    def test_type_check_kwargs_and_static_class(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            @type_check(a=int, b=str)
+            def kw_only(a, b):
+                return f"{a}-{b}"
+
+            self.assertEqual(kw_only(a=1, b="x"), "1-x")
+            kw_only(a=1, b=2)
+            self.assertTrue(any(issubclass(x.category, UserWarning) for x in w))
+
+        class Demo:
+            @type_check(int)
+            @staticmethod
+            def static_add(n):
+                return n
+
+            @type_check(object, int)
+            @classmethod
+            def class_add(cls, n):
+                return n
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            self.assertEqual(Demo.static_add(1), 1)
+            Demo.static_add("x")
+            self.assertTrue(any(issubclass(x.category, UserWarning) for x in w))
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            self.assertEqual(Demo.class_add(1), 1)
+            Demo.class_add("x")
+            self.assertTrue(any(issubclass(x.category, UserWarning) for x in w))
+

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -6,6 +6,7 @@ import threading
 import unittest
 from base64 import b64encode
 from datetime import datetime
+from unittest import mock
 from urllib.parse import urlparse
 
 import websocket as ws_client
@@ -15,6 +16,7 @@ from darabonba.runtime import RuntimeOptions
 from darabonba.websocket import (
     AbstractWebSocketHandler,
     DefaultWebSocketClient,
+    STATE_CONNECTED,
     WebSocketMessage,
     WebSocketMessageType,
     WebSocketSessionInfo,
@@ -522,6 +524,137 @@ class TestWebSocket(unittest.TestCase):
             self.assertEqual('general', header.get('sec-websocket-protocol'))
         finally:
             ws_lib.WebSocketApp.__init__ = original_init
+
+    def _make_client_for_unit(self, enable_reconnect=True, max_times=5):
+        handler = MockWebSocketHandler()
+        client = new_default_websocket_client(handler)
+        request = DaraRequest()
+        request.protocol = 'ws'
+        request.domain = '127.0.0.1:19999'
+        request.pathname = '/'
+        request.headers = {'host': '127.0.0.1:19999'}
+        client.request = request
+        client.runtime_object = RuntimeOptions(
+            web_socket_enable_reconnect=enable_reconnect,
+            web_socket_max_reconnect_times=max_times,
+            web_socket_reconnect_interval=1,
+            web_socket_write_timeout=50,
+        )
+        client.reconnect_interval = 1
+        client.max_reconnect_times = max_times
+        client.write_timeout = 50
+        client._sleep_interruptible = lambda _ms: True
+        client._cleanup_resources = mock.MagicMock()
+        return client, handler
+
+    def test_reconnect_disabled_and_limits(self):
+        client, _handler = self._make_client_for_unit(enable_reconnect=False)
+        with self.assertRaisesRegex(Exception, 'reconnect is disabled'):
+            client.reconnect()
+
+        client, _handler = self._make_client_for_unit(enable_reconnect=True, max_times=1)
+        client.reconnect_count = 1
+        with self.assertRaisesRegex(Exception, 'max reconnect times reached'):
+            client.reconnect()
+
+        client, _handler = self._make_client_for_unit()
+        client.state = STATE_CONNECTED
+        with self.assertRaisesRegex(Exception, 'already connected'):
+            client.reconnect()
+
+        client, _handler = self._make_client_for_unit()
+        client._abort_event.set()
+        with self.assertRaisesRegex(Exception, 'connection aborted'):
+            client.reconnect()
+
+    def test_reconnect_already_in_progress(self):
+        client, _handler = self._make_client_for_unit()
+        self.assertTrue(client._reconnect_lock.acquire(blocking=False))
+        try:
+            with self.assertRaisesRegex(Exception, 'reconnect already in progress'):
+                client.reconnect()
+        finally:
+            client._reconnect_lock.release()
+
+    def test_reconnect_success_and_graceful(self):
+        client, _handler = self._make_client_for_unit()
+        client.connect = mock.MagicMock(return_value=mock.MagicMock())
+        result = client.reconnect()
+        self.assertIsNotNone(result)
+        self.assertEqual(0, client.reconnect_count)
+        client.connect.assert_called_once()
+
+        client, _handler = self._make_client_for_unit()
+        client.session = WebSocketSessionInfo(session_id='sid-1')
+        client.connect = mock.MagicMock(return_value=mock.MagicMock())
+        client.reconnect_gracefully()
+        self.assertEqual('sid-1', client.request.headers.get('X-Acs-Ws-Session-Id'))
+
+        client, _handler = self._make_client_for_unit()
+        client.session = None
+        with self.assertRaisesRegex(Exception, 'graceful reconnection requires existing session ID'):
+            client.reconnect_gracefully()
+
+    def test_send_binary_and_on_message_close(self):
+        client, handler = self._make_client_for_unit()
+        with self.assertRaisesRegex(Exception, 'not connected'):
+            client.send_binary(b'x')
+
+        client.state = STATE_CONNECTED
+        client.ws_app = mock.MagicMock()
+        client.send_binary(b'bin-data')
+        client.ws_app.send.assert_called()
+
+        client.session = WebSocketSessionInfo(session_id='sid')
+        client.stopped = False
+        client._on_message(None, 'hello-text')
+        client._on_message(None, b'hello-bin')
+        self.assertEqual(2, handler.message_received_count)
+
+        def boom(_session, _msg):
+            raise RuntimeError('handler failed')
+
+        handler.handle_raw_message = boom
+        client._on_message(None, 'fail')
+        self.assertEqual(1, handler.error_count)
+
+        client.reconnect = mock.MagicMock(side_effect=Exception('skip'))
+        client._on_close(None, 1006, 'abnormal')
+        client.reconnect.assert_called_once()
+
+    def test_configure_socks5_and_tls_cert(self):
+        client, _handler = self._make_client_for_unit()
+        runtime = RuntimeOptions(socks_5proxy='127.0.0.1:1080')
+        socks = client.configure_socks5_proxy(runtime)
+        self.assertEqual('socks5', socks.get('proxy_type'))
+        self.assertEqual('127.0.0.1:1080', socks.get('http_proxy_host'))
+
+        parsed = urlparse('wss://example.com/')
+        request = DaraRequest()
+        request.headers = {}
+        proxy = client._configure_proxy(parsed, runtime, request)
+        self.assertEqual('socks5', proxy.get('proxy_type'))
+
+        tls = client._configure_tls(
+            RuntimeOptions(cert='/c.pem', key='/k.pem', ca='/ca.pem', ignore_ssl=False),
+            'wss',
+        )
+        self.assertEqual('/c.pem', tls.get('certfile'))
+        self.assertEqual('/k.pem', tls.get('keyfile'))
+        self.assertEqual('/ca.pem', tls.get('ca_certs'))
+
+    def test_send_with_timeout_paths(self):
+        client, _handler = self._make_client_for_unit()
+        client.write_timeout = 1000
+        client._send_with_timeout(lambda: None)
+
+        client.write_timeout = 10
+
+        def blockers():
+            raise TimeoutError('timeout')
+
+        with self.assertRaises(Exception):
+            client._send_with_timeout(blockers)
 
 
 if __name__ == '__main__':

--- a/tests/utils/test_form.py
+++ b/tests/utils/test_form.py
@@ -109,7 +109,71 @@ class TestForm(unittest.TestCase):
         form_str = b''.join(body)
         self.assertEqual(content.encode(), form_str)
         self.assertEqual(len(content.encode()), len(form_str))
-        
+
+    def test_to_form_string_skips_readable(self):
+        form = {
+            'a': '1',
+            'f': BytesIO(b'x'),
+        }
+        self.assertEqual('a=1', Form.to_form_string(form))
+
+    def test_file_form_chunked_len_and_refresh(self):
+        content = b'0123456789abcdef'
+        file_field = FileField(
+            filename='chunk.txt',
+            content_type='text/plain',
+            content=BytesIO(content),
+        )
+        form = {
+            'k': 'v',
+            'file': file_field,
+        }
+        body = Form.to_file_form(form, 'boundary')
+        total_len = len(body)
+        self.assertGreater(total_len, 0)
+
+        chunks = []
+        while True:
+            chunk = body.read(size=32)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        joined = b''.join(chunks)
+        self.assertEqual(total_len, len(joined))
+        self.assertIn(b'chunk.txt', joined)
+
+        body.refresh()
+        refreshed = body.read()
+        self.assertIn(b'chunk.txt', refreshed)
+
+        class StrReadable:
+            def __init__(self, data):
+                self._data = data
+                self._pos = 0
+                self.len = len(data)
+
+            def read(self, size=-1):
+                if self._pos >= len(self._data):
+                    return ''
+                if size is None or size < 0:
+                    size = len(self._data) - self._pos
+                out = self._data[self._pos:self._pos + size]
+                self._pos += len(out)
+                return out
+
+            def seek(self, *_args):
+                self._pos = 0
+
+        str_field = FileField(
+            filename='s.txt',
+            content_type='text/plain',
+            content=StrReadable('hello-str'),
+        )
+        body2 = Form.to_file_form({'file': str_field}, 'b')
+        data = b''.join(list(body2))
+        self.assertIn(b'hello-str', data)
+
+
 class TestFileField(unittest.TestCase):
     
     def test_file_field_validate(self):

--- a/tests/utils/test_stream.py
+++ b/tests/utils/test_stream.py
@@ -311,3 +311,164 @@ class TestStream(unittest.TestCase):
             mock_response.close.assert_called_once()
         
         asyncio.run(run_test())
+
+    def _fat_sse_chunks(self, include_bad_utf8=False):
+        chunks = [
+            b': comment\n',
+            b'id: 1\nevent: create\ndata: line1\ndata: line2\nretry: 3000\nretry: bad\n\n',
+            b'bare-data-line\n\n',
+            # leftover buffer after a completed data line triggers final flush
+            b'data: trailing\nleftover',
+        ]
+        if include_bad_utf8:
+            chunks.insert(2, b'\xff\xfe')
+        return chunks
+
+    def test_readable_isinstance_and_read_as_bytes_loop(self):
+        stream = BaseStream()
+        self.assertRaises(NotImplementedError, stream.read)
+        self.assertRaises(NotImplementedError, stream.__len__)
+        self.assertRaises(NotImplementedError, stream.__next__)
+        self.assertIsInstance(stream, READABLE)
+
+        with open(os.path.join(root_path, 'test.txt'), 'rb') as f:
+            self.assertIsInstance(f, READABLE)
+            self.assertIsInstance(f, STREAM_CLASS)
+
+        with open(os.path.join(root_path, 'test.txt'), 'wb') as f:
+            self.assertIsInstance(f, WRITABLE)
+            self.assertIsInstance(f, STREAM_CLASS)
+
+        with BytesIO(b'test') as bio:
+            self.assertIsInstance(bio, READABLE)
+            self.assertIsInstance(bio, STREAM_CLASS)
+            self.assertEqual(Stream.read_as_bytes(bio), b'test')
+
+    def test_to_readable(self):
+        readable = Stream.to_readable('hello')
+        self.assertEqual(readable.read(), b'hello')
+        readable = Stream.to_readable(b'bytes')
+        self.assertEqual(readable.read(), b'bytes')
+        bio = BytesIO(b'passthrough')
+        self.assertIs(Stream.to_readable(bio), bio)
+        with self.assertRaises(ValueError):
+            Stream.to_readable(123)
+
+    def _assert_fat_sse_results(self, results):
+        self.assertGreaterEqual(len(results), 3)
+        self.assertEqual(results[0].id, '1')
+        self.assertEqual(results[0].event, 'create')
+        self.assertEqual(results[0].data, 'line1\nline2')
+        self.assertEqual(results[0].retry, 3000)
+        self.assertEqual(results[1].data, 'bare-data-line')
+        self.assertEqual(results[2].data, 'trailing')
+
+    def test_read_as_sse_from_iter_content_edges(self):
+        mock_response = mock.MagicMock()
+        mock_response.iter_content.return_value = self._fat_sse_chunks(include_bad_utf8=True)
+        self._assert_fat_sse_results(list(Stream.read_as_sse(mock_response)))
+
+    def test_read_as_sse_sync_wrapper_edges(self):
+        mock_session = mock.MagicMock()
+        mock_response = mock.MagicMock()
+        mock_response.iter_content.return_value = self._fat_sse_chunks(include_bad_utf8=True)
+        from darabonba.utils.stream import SyncSSEResponseWrapper
+        wrapper = SyncSSEResponseWrapper(mock_session, mock_response)
+        self._assert_fat_sse_results(list(Stream.read_as_sse(wrapper)))
+
+    def test_read_as_sse_async_wrapper_edges(self):
+        async def run_test():
+            mock_session = mock.MagicMock()
+
+            async def mock_session_close():
+                pass
+
+            mock_session.close = mock_session_close
+            mock_response = mock.MagicMock()
+            chunks = self._fat_sse_chunks()
+
+            async def iter_chunked(_size=8192):
+                for chunk in chunks:
+                    yield chunk
+
+            mock_response.content.iter_chunked = iter_chunked
+            mock_response.close = mock.MagicMock()
+
+            from darabonba.utils.stream import SSEResponseWrapper
+            wrapper = SSEResponseWrapper(mock_session, mock_response)
+            results = []
+            async for event in Stream.read_as_sse_async(wrapper):
+                results.append(event)
+            self._assert_fat_sse_results(results)
+
+        asyncio.run(run_test())
+
+    def test_read_as_sse_async_from_aiohttp_content(self):
+        async def run_test():
+            chunks = self._fat_sse_chunks(include_bad_utf8=True)
+
+            async def iter_chunked(_size=8192):
+                for chunk in chunks:
+                    yield chunk
+
+            mock_response = mock.MagicMock()
+            mock_response.content.iter_chunked = iter_chunked
+            results = []
+            async for event in Stream.read_as_sse_async(mock_response):
+                results.append(event)
+            self._assert_fat_sse_results(results)
+
+        asyncio.run(run_test())
+
+    def test_read_as_sse_plain_iterable_fallback(self):
+        chunks = self._fat_sse_chunks()
+        self._assert_fat_sse_results(list(Stream.read_as_sse(chunks)))
+
+        async def run_test():
+            async def agen():
+                for chunk in chunks:
+                    yield chunk
+
+            results = []
+            async for event in Stream.read_as_sse_async(agen()):
+                results.append(event)
+            self._assert_fat_sse_results(results)
+
+        asyncio.run(run_test())
+
+    def test_sse_response_wrapper_read_cache_and_aiter(self):
+        async def run_test():
+            mock_session = mock.MagicMock()
+
+            async def mock_session_close():
+                pass
+
+            mock_session.close = mock_session_close
+            mock_response = mock.MagicMock()
+            calls = {'n': 0}
+
+            async def mock_read():
+                calls['n'] += 1
+                return b'cached-body'
+
+            mock_response.read = mock_read
+            mock_response.close = mock.MagicMock()
+
+            async def iter_chunked(_size=8192):
+                yield b'data: from-aiter\n\n'
+
+            mock_response.content.iter_chunked = iter_chunked
+
+            from darabonba.utils.stream import SSEResponseWrapper
+            wrapper = SSEResponseWrapper(mock_session, mock_response)
+            self.assertEqual(await wrapper.read(), b'cached-body')
+            self.assertEqual(await wrapper.read(), b'cached-body')
+            self.assertEqual(calls['n'], 1)
+
+            wrapper2 = SSEResponseWrapper(mock_session, mock_response)
+            chunks = []
+            async for chunk in wrapper2:
+                chunks.append(chunk)
+            self.assertEqual(chunks, [b'data: from-aiter\n\n'])
+
+        asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- Wire RuntimeOptions / OpenAPI `maxIdleConns` into urllib3 `pool_maxsize` and aiohttp connector limits (align with Go tea).
- Fixes https://github.com/aliyun/tea-python/issues/100 where concurrent calls hit "Connection pool is full".
- Add unit tests for pool size resolution, adapter config, and `do_action` forwarding.