### PR TITLE
fix: exponential backoff should be period * 2^retries

### DIFF
--- a/darabonba/policy/retry.py
+++ b/darabonba/policy/retry.py
@@ -99,7 +99,8 @@ class ExponentialBackoffPolicy(BackoffPolicy):
         }
 
     def get_delay_time(self, ctx: 'RetryPolicyContext') -> int:
-        random_time = min(2 ** (ctx.retries_attempted * self.period), self.cap)
+        # period * 2^retries (align with C# / standard exponential backoff)
+        random_time = min(self.period * (2 ** ctx.retries_attempted), self.cap)
         return random_time
 
 class EqualJitterBackoffPolicy(BackoffPolicy):
@@ -117,7 +118,7 @@ class EqualJitterBackoffPolicy(BackoffPolicy):
         }
 
     def get_delay_time(self, ctx: 'RetryPolicyContext') -> int:
-        ceil = min(self.cap, 2 ** (ctx.retries_attempted * self.period))
+        ceil = min(self.cap, self.period * (2 ** ctx.retries_attempted))
         return ceil // 2 + random.randint(0, ceil // 2)
 
 class FullJitterBackoffPolicy(BackoffPolicy):
@@ -134,7 +135,7 @@ class FullJitterBackoffPolicy(BackoffPolicy):
         }
 
     def get_delay_time(self, ctx: 'RetryPolicyContext') -> int:
-        ceil = min(self.cap, 2 ** (ctx.retries_attempted * self.period))
+        ceil = min(self.cap, self.period * (2 ** ctx.retries_attempted))
         return random.randint(0, ceil)
 
 class RetryCondition:

--- a/tests/policy/test_retry.py
+++ b/tests/policy/test_retry.py
@@ -72,30 +72,34 @@ class TestBackoffPolicy(unittest.TestCase):
         policy = ExponentialBackoffPolicy({'period': 1, 'cap': 10000})
         ctx = RetryPolicyContext(retries_attempted=5)
         delay_time = policy.get_delay_time(ctx)
-        self.assertGreaterEqual(delay_time, 0)
-        self.assertLessEqual(delay_time, 10000)
+        self.assertEqual(delay_time, 32)  # 1 * 2^5
+        # period=1000 must multiply, not enter the exponent
+        policy = ExponentialBackoffPolicy({'period': 1000, 'cap': 10000})
+        self.assertEqual(policy.get_delay_time(RetryPolicyContext(retries_attempted=1)), 2000)
+        self.assertEqual(policy.get_delay_time(RetryPolicyContext(retries_attempted=2)), 4000)
+        self.assertEqual(policy.get_delay_time(RetryPolicyContext(retries_attempted=4)), 10000)  # capped
         option = {'policy': 'Exponential', 'period': 100, 'cap': 100000}
         exponential_policy = ExponentialBackoffPolicy(option)
         expected_map = {'policy': 'Exponential', 'period': 100, 'cap': 100000}
         self.assertEqual(exponential_policy.to_map(), expected_map)
 
     def test_equal_jitter_backoff_policy(self):
-        policy = EqualJitterBackoffPolicy({'period': 1, 'cap': 10000})
-        ctx = RetryPolicyContext(retries_attempted=5)
+        policy = EqualJitterBackoffPolicy({'period': 1000, 'cap': 10000})
+        ctx = RetryPolicyContext(retries_attempted=2)
         delay_time = policy.get_delay_time(ctx)
-        self.assertGreaterEqual(delay_time, 0)
-        self.assertLessEqual(delay_time, 10000)
+        self.assertGreaterEqual(delay_time, 2000)
+        self.assertLessEqual(delay_time, 4000)
         option = {'policy': 'EqualJitter', 'period': 100, 'cap': 100000}
         equal_jitter_policy = EqualJitterBackoffPolicy(option)
         expected_map = {'policy': 'EqualJitter', 'period': 100, 'cap': 100000}
         self.assertEqual(equal_jitter_policy.to_map(), expected_map)
 
     def test_full_jitter_backoff_policy(self):
-        policy = FullJitterBackoffPolicy({'period': 1, 'cap': 10000})
-        ctx = RetryPolicyContext(retries_attempted=5)
+        policy = FullJitterBackoffPolicy({'period': 1000, 'cap': 10000})
+        ctx = RetryPolicyContext(retries_attempted=2)
         delay_time = policy.get_delay_time(ctx)
         self.assertGreaterEqual(delay_time, 0)
-        self.assertLessEqual(delay_time, 10000)
+        self.assertLessEqual(delay_time, 4000)
         option = {'policy': 'FullJitter', 'period': 100, 'cap': 100000}
         full_jitter_policy = FullJitterBackoffPolicy(option)
         expected_map = {'policy': 'FullJitter', 'period': 100, 'cap': 100000}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1461,6 +1461,7 @@ class TestRetry(unittest.TestCase):
         })
         self.assertEqual(DaraCore.get_backoff_time(option, ctx), 10)
         
+        # period * 2^retries: period=5, retries=2 → 5*4=20
         exponentialPolicy = BackoffPolicy.new_backoff_policy({"policy": "Exponential", "period": 5, "cap": 10000})
         condition3 = RetryCondition({
             'maxAttempts': 3,
@@ -1472,7 +1473,21 @@ class TestRetry(unittest.TestCase):
             'retryable': True,
             'retryCondition': [condition3]
         })
-        self.assertEqual(DaraCore.get_backoff_time(option, ctx), 1024)
+        self.assertEqual(DaraCore.get_backoff_time(option, ctx), 20)
+
+        # period=1000ms, retries=2 → 1000*4=4000 (must not treat period as exponent)
+        exponentialPolicy = BackoffPolicy.new_backoff_policy({"policy": "Exponential", "period": 1000, "cap": 10000})
+        condition3b = RetryCondition({
+            'maxAttempts': 3,
+            'exception': ['AErr'],
+            'errorCode': ['A1Err'],
+            "backoff": exponentialPolicy,
+        })
+        option = RetryOptions({
+            'retryable': True,
+            'retryCondition': [condition3b]
+        })
+        self.assertEqual(DaraCore.get_backoff_time(option, ctx), 4000)
         
         exponentialPolicy = BackoffPolicy.new_backoff_policy({"policy": "Exponential", "period": 10, "cap": 10000})
         condition4 = RetryCondition({
@@ -1485,7 +1500,7 @@ class TestRetry(unittest.TestCase):
             'retryable': True,
             'retryCondition': [condition4]
         })
-        self.assertEqual(DaraCore.get_backoff_time(option, ctx), 10000)
+        self.assertEqual(DaraCore.get_backoff_time(option, ctx), 40)
         
         equalJitterPolicy = BackoffPolicy.new_backoff_policy({"policy": "EqualJitter", "period": 5, "cap": 10000})
         condition5 = RetryCondition({
@@ -1499,9 +1514,9 @@ class TestRetry(unittest.TestCase):
             'retryCondition': [condition5]
         })
         backoffTime = DaraCore.get_backoff_time(option, ctx)
-        self.assertTrue(backoffTime > 512 and backoffTime < 1024)
+        self.assertTrue(backoffTime >= 10 and backoffTime <= 20)
         
-        equalJitterPolicy = BackoffPolicy.new_backoff_policy({"policy": "EqualJitter", "period": 10, "cap": 10000})
+        equalJitterPolicy = BackoffPolicy.new_backoff_policy({"policy": "EqualJitter", "period": 1000, "cap": 10000})
         condition6 = RetryCondition({
             'maxAttempts': 3,
             'exception': ['AErr'],
@@ -1513,7 +1528,7 @@ class TestRetry(unittest.TestCase):
             'retryCondition': [condition6]
         })
         backoffTime = DaraCore.get_backoff_time(option, ctx)
-        self.assertTrue(backoffTime > 5000 and backoffTime < 10000)
+        self.assertTrue(backoffTime >= 2000 and backoffTime <= 4000)
         
         fullJitterPolicy = BackoffPolicy.new_backoff_policy({"policy": "FullJitter", "period": 5, "cap": 10000})
         condition7 = RetryCondition({
@@ -1527,7 +1542,7 @@ class TestRetry(unittest.TestCase):
             'retryCondition': [condition7]
         })
         backoffTime = DaraCore.get_backoff_time(option, ctx)
-        self.assertTrue(backoffTime > 0 and backoffTime < 1024)
+        self.assertTrue(backoffTime >= 0 and backoffTime <= 20)
         
         fullJitterPolicy = BackoffPolicy.new_backoff_policy({"policy": "ExponentialWithFullJitter", "period": 10, "cap": 10000})
         condition8 = RetryCondition({


### PR DESCRIPTION
## Summary
- Fix Exponential / EqualJitter / FullJitter backoff to `period * 2^retries` (was incorrectly `2^(retries * period)`).
- Align with C# Tea implementation so millisecond periods no longer jump straight to the cap.
- Add / update unit tests with `period=1000` vectors.